### PR TITLE
Feat/is media type allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ or directly
 ## CLI
 
 ```sh
-openapi-zod-client/0.2.2
+openapi-zod-client/0.2.3
 
 Usage:
   $ openapi-zod-client <input>
@@ -44,16 +44,17 @@ For more info, run any command with the `--help` flag:
   $ openapi-zod-client --help
 
 Options:
-  -o, --output <path>    Output path for the zodios api client ts file (defaults to `<input>.client.ts`)
-  -t, --template <path>  Template path for the handlebars template that will be used to generate the output
-  -p, --prettier <path>  Prettier config path that will be used to format the output client file
-  -b, --base-url <url>   Base url for the api
-  -a, --with-alias       With alias as api client methods
-  --error-expr <expr>    Pass an expression to determine if a response status is an error
-  --success-expr <expr>  Pass an expression to determine which response status is the main success status
-  --export-schemas       When true, will export all `#/components/schemas` even if not used in any paths
-  -v, --version          Display version number
-  -h, --help             Display this message
+  -o, --output <path>       Output path for the zodios api client ts file (defaults to `<input>.client.ts`)
+  -t, --template <path>     Template path for the handlebars template that will be used to generate the output
+  -p, --prettier <path>     Prettier config path that will be used to format the output client file
+  -b, --base-url <url>      Base url for the api
+  -a, --with-alias          With alias as api client methods
+  --error-expr <expr>       Pass an expression to determine if a response status is an error
+  --success-expr <expr>     Pass an expression to determine which response status is the main success status
+  --media-type-expr <expr>  Pass an expression to determine which response content should be allowed
+  --export-schemas          When true, will export all `#/components/schemas`
+  -v, --version             Display version number
+  -h, --help                Display this message
 
 ```
 

--- a/example/petstore-client.ts
+++ b/example/petstore-client.ts
@@ -1,4 +1,4 @@
-import { asApi, Zodios } from "@zodios/core";
+import { makeApi, Zodios } from "@zodios/core";
 import { z } from "zod";
 
 const vR1x0k5qaLk = z.object({ id: z.number(), name: z.string() }).partial();
@@ -64,7 +64,7 @@ const variables = {
     uploadFile: vBaxCoPHbgy,
 };
 
-const endpoints = asApi([
+const endpoints = makeApi([
     {
         method: "put",
         path: "/pet",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "openapi-zod-client",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "repository": {
         "type": "git",
         "url": "https://github.com/astahmer/openapi-zod-client.git"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dependencies": {
         "@apidevtools/swagger-parser": "^10.1.0",
         "@babel/core": "^7.19.1",
-        "@zodios/core": "^9.0.1",
+        "@zodios/core": "^9.3.3",
         "axios": "^0.27.2",
         "cac": "^6.7.14",
         "handlebars": "^4.7.7",
@@ -36,8 +36,8 @@
         "prettier": "^2.7.1",
         "tanu": "^0.1.13",
         "ts-pattern": "^4.0.5",
-        "zod": "^3.19.1",
-        "whence": "^2.0.0"
+        "whence": "^2.0.0",
+        "zod": "^3.19.1"
     },
     "devDependencies": {
         "@babel/preset-env": "^7.19.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ specifiers:
   '@types/js-yaml': ^4.0.5
   '@types/node': ^18.7.18
   '@types/prettier': ^2.7.0
-  '@zodios/core': ^9.0.1
+  '@zodios/core': ^9.3.3
   axios: ^0.27.2
   cac: ^6.7.14
   degit: ^2.8.4
@@ -35,7 +35,7 @@ specifiers:
 dependencies:
   '@apidevtools/swagger-parser': 10.1.0_openapi-types@12.0.2
   '@babel/core': 7.19.1
-  '@zodios/core': 9.0.1_axios@0.27.2+zod@3.19.1
+  '@zodios/core': 9.3.3_axios@0.27.2+zod@3.19.1
   axios: 0.27.2
   cac: 6.7.14
   handlebars: 4.7.7
@@ -46,6 +46,7 @@ dependencies:
   prettier: 2.7.1
   tanu: 0.1.13
   ts-pattern: 4.0.5
+  whence: 2.0.0
   zod: 3.19.1
 
 devDependencies:
@@ -64,7 +65,6 @@ devDependencies:
   type-fest: 2.19.0
   typescript: 4.8.3
   vitest: 0.22.1
-  whence: 2.0.0
 
 packages:
 
@@ -1630,8 +1630,8 @@ packages:
       '@types/node': 18.7.18
     dev: true
 
-  /@zodios/core/9.0.1_axios@0.27.2+zod@3.19.1:
-    resolution: {integrity: sha512-SJ0U4U5w6MBiGNy3L/n6Wv8Ju0hpP5BGxB8XxccuFuPWDtfsRgC++rjKMpfkRlH4ambJUECNh7L/ISdbWwzRCQ==}
+  /@zodios/core/9.3.3_axios@0.27.2+zod@3.19.1:
+    resolution: {integrity: sha512-hGAWXWWnco/pSp1jaIDZglUX+yW89aNAdgUlRWgfzMWRIqm94XmDY7HlqPCEfJ/649zwTb9vbNYPKRlv0vkL3A==}
     peerDependencies:
       axios: ^0.x
       zod: ^3.x
@@ -2277,7 +2277,7 @@ packages:
 
   /eval-estree-expression/1.1.0:
     resolution: {integrity: sha512-6ZAHSb0wsqxutjk2lXZcW7btSc51I8BhlIetit0wIf5sOb5xDNBrIqe0g8RFyQ/EW6Xwn1szrtButztU7Vdj1Q==}
-    dev: true
+    dev: false
 
   /fast-deep-equal/2.0.1:
     resolution: {integrity: sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==}
@@ -2434,7 +2434,7 @@ packages:
       source-map: 0.6.1
       wordwrap: 1.0.0
     optionalDependencies:
-      uglify-js: 3.17.0
+      uglify-js: 3.17.2
     dev: false
 
   /hard-rejection/2.1.0:
@@ -3343,8 +3343,8 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  /uglify-js/3.17.0:
-    resolution: {integrity: sha512-aTeNPVmgIMPpm1cxXr2Q/nEbvkmV8yq66F3om7X3P/cvOXQ0TMQ64Wk63iyT1gPlmdmGzjGpyLh1f3y8MZWXGg==}
+  /uglify-js/3.17.2:
+    resolution: {integrity: sha512-bbxglRjsGQMchfvXZNusUcYgiB9Hx2K4AHYXQy2DITZ9Rd+JzhX7+hoocE5Winr7z2oHvPsekkBwXtigvxevXg==}
     engines: {node: '>=0.8.0'}
     hasBin: true
     requiresBuild: true
@@ -3482,7 +3482,7 @@ packages:
     dependencies:
       '@babel/parser': 7.19.1
       eval-estree-expression: 1.1.0
-    dev: true
+    dev: false
 
   /wordwrap/1.0.0:
     resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}

--- a/src/__snapshots__/samples.test.ts.snap
+++ b/src/__snapshots__/samples.test.ts.snap
@@ -1,31 +1,31 @@
 // Vitest Snapshot v1
 
 exports[`samples-generator > ./samples/v3.0/api-with-examples.yaml 1`] = `
-"import { asApi, Zodios } from "@zodios/core";
+"import { makeApi, Zodios } from "@zodios/core";
 import { z } from "zod";
 
 const variables = {};
 
-const endpoints = asApi([]);
+const endpoints = makeApi([]);
 
 export const api = new Zodios(endpoints);
 "
 `;
 
 exports[`samples-generator > ./samples/v3.0/callback-example.yaml 1`] = `
-"import { asApi, Zodios } from "@zodios/core";
+"import { makeApi, Zodios } from "@zodios/core";
 import { z } from "zod";
 
 const variables = {};
 
-const endpoints = asApi([]);
+const endpoints = makeApi([]);
 
 export const api = new Zodios(endpoints);
 "
 `;
 
 exports[`samples-generator > ./samples/v3.0/link-example.yaml 1`] = `
-"import { asApi, Zodios } from "@zodios/core";
+"import { makeApi, Zodios } from "@zodios/core";
 import { z } from "zod";
 
 const vObntp1skbx = z.object({ username: z.string(), uuid: z.string() }).partial();
@@ -49,7 +49,7 @@ const variables = {
     user: vObntp1skbx,
 };
 
-const endpoints = asApi([
+const endpoints = makeApi([
     {
         method: "get",
         path: "/2.0/repositories/:username",
@@ -94,7 +94,7 @@ export const api = new Zodios(endpoints);
 `;
 
 exports[`samples-generator > ./samples/v3.0/petstore.yaml 1`] = `
-"import { asApi, Zodios } from "@zodios/core";
+"import { makeApi, Zodios } from "@zodios/core";
 import { z } from "zod";
 
 const vz089ZHJr6H = z.object({ id: z.number(), name: z.string(), tag: z.string().optional() });
@@ -110,7 +110,7 @@ const variables = {
     showPetById: vusbpdVpqWm,
 };
 
-const endpoints = asApi([
+const endpoints = makeApi([
     {
         method: "get",
         path: "/pets",
@@ -143,7 +143,7 @@ export const api = new Zodios(endpoints);
 `;
 
 exports[`samples-generator > ./samples/v3.0/petstore-expanded.yaml 1`] = `
-"import { asApi, Zodios } from "@zodios/core";
+"import { makeApi, Zodios } from "@zodios/core";
 import { z } from "zod";
 
 const vPXNN6VHlNv = z.object({ name: z.string(), tag: z.string().optional() });
@@ -163,7 +163,7 @@ const variables = {
     tags: vGqL1kemtHF,
 };
 
-const endpoints = asApi([
+const endpoints = makeApi([
     {
         method: "get",
         path: "/pets",
@@ -223,7 +223,7 @@ export const api = new Zodios(endpoints);
 `;
 
 exports[`samples-generator > ./samples/v3.0/uspto.yaml 1`] = `
-"import { asApi, Zodios } from "@zodios/core";
+"import { makeApi, Zodios } from "@zodios/core";
 import { z } from "zod";
 
 const vIEeBL2OSmC = z
@@ -249,7 +249,7 @@ const variables = {
     perform_search: vlyQvttKNVV,
 };
 
-const endpoints = asApi([
+const endpoints = makeApi([
     {
         method: "get",
         path: "/",
@@ -284,24 +284,24 @@ export const api = new Zodios(endpoints);
 `;
 
 exports[`samples-generator > ./samples/v3.1/non-oauth-scopes.yaml 1`] = `
-"import { asApi, Zodios } from "@zodios/core";
+"import { makeApi, Zodios } from "@zodios/core";
 import { z } from "zod";
 
 const variables = {};
 
-const endpoints = asApi([]);
+const endpoints = makeApi([]);
 
 export const api = new Zodios(endpoints);
 "
 `;
 
 exports[`samples-generator > ./samples/v3.1/webhook-example.yaml 1`] = `
-"import { asApi, Zodios } from "@zodios/core";
+"import { makeApi, Zodios } from "@zodios/core";
 import { z } from "zod";
 
 const variables = {};
 
-const endpoints = asApi([]);
+const endpoints = makeApi([]);
 
 export const api = new Zodios(endpoints);
 "

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ cli.command("<input>", "path/url to OpenAPI/Swagger document as json/yaml")
     .option("-a, --with-alias", "With alias as api client methods")
     .option("--error-expr <expr>", "Pass an expression to determine if a response status is an error")
     .option("--success-expr <expr>", "Pass an expression to determine which response status is the main success status")
+    .option("--media-type-expr <expr>", "Pass an expression to determine which response content should be allowed")
     .option("--export-schemas", "When true, will export all `#/components/schemas`")
     .action(async (input, options) => {
         console.log("Retrieving OpenAPI document from", input);
@@ -40,6 +41,7 @@ cli.command("<input>", "path/url to OpenAPI/Swagger document as json/yaml")
                 isErrorStatus: options.errorExpr,
                 isMainResponseStatus: options.successExpr,
                 shouldExportAllSchemas: options.exportSchemas,
+                isMediaTypeAllowed: options.mediaTypeExpr,
             },
         });
         console.log(`Done generating <${distPath}> !`);

--- a/src/generateZodClientFromOpenAPI.test.ts
+++ b/src/generateZodClientFromOpenAPI.test.ts
@@ -268,7 +268,7 @@ describe("generateZodClientFromOpenAPI", () => {
         const output = template(data);
         const prettyOutput = maybePretty(output, prettierConfig);
         expect(prettyOutput).toMatchInlineSnapshot(`
-          "import { asApi, Zodios } from "@zodios/core";
+          "import { makeApi, Zodios } from "@zodios/core";
           import { z } from "zod";
 
           const vR1x0k5qaLk = z.object({ id: z.number(), name: z.string() }).partial();
@@ -334,7 +334,7 @@ describe("generateZodClientFromOpenAPI", () => {
               uploadFile: vBaxCoPHbgy,
           };
 
-          const endpoints = asApi([
+          const endpoints = makeApi([
               {
                   method: "put",
                   path: "/pet",
@@ -511,7 +511,7 @@ describe("generateZodClientFromOpenAPI", () => {
         const output = template({ ...data, options: { withAlias: true } } as TemplateContext);
         const prettyOutput = maybePretty(output, prettierConfig);
         expect(prettyOutput).toMatchInlineSnapshot(`
-          "import { asApi, Zodios } from "@zodios/core";
+          "import { makeApi, Zodios } from "@zodios/core";
           import { z } from "zod";
 
           const vR1x0k5qaLk = z.object({ id: z.number(), name: z.string() }).partial();
@@ -577,7 +577,7 @@ describe("generateZodClientFromOpenAPI", () => {
               uploadFile: vBaxCoPHbgy,
           };
 
-          const endpoints = asApi([
+          const endpoints = makeApi([
               {
                   method: "put",
                   path: "/pet",
@@ -767,7 +767,7 @@ describe("generateZodClientFromOpenAPI", () => {
         const output = template({ ...data, options: { baseUrl: "http://example.com" } } as TemplateContext);
         const prettyOutput = maybePretty(output, prettierConfig);
         expect(prettyOutput).toMatchInlineSnapshot(`
-          "import { asApi, Zodios } from "@zodios/core";
+          "import { makeApi, Zodios } from "@zodios/core";
           import { z } from "zod";
 
           const vR1x0k5qaLk = z.object({ id: z.number(), name: z.string() }).partial();
@@ -833,7 +833,7 @@ describe("generateZodClientFromOpenAPI", () => {
               uploadFile: vBaxCoPHbgy,
           };
 
-          const endpoints = asApi([
+          const endpoints = makeApi([
               {
                   method: "put",
                   path: "/pet",
@@ -1163,7 +1163,7 @@ test("with optional, partial, all required objects", async () => {
     const output = template(data);
     const prettyOutput = maybePretty(output, prettierConfig);
     expect(prettyOutput).toMatchInlineSnapshot(`
-      "import { asApi, Zodios } from "@zodios/core";
+      "import { makeApi, Zodios } from "@zodios/core";
       import { z } from "zod";
 
       type Nested2 = {
@@ -1218,7 +1218,7 @@ test("with optional, partial, all required objects", async () => {
           getRoot: vCj2di4DExd,
       };
 
-      const endpoints = asApi([
+      const endpoints = makeApi([
           {
               method: "get",
               path: "/nested",

--- a/src/generateZodClientFromOpenAPI.ts
+++ b/src/generateZodClientFromOpenAPI.ts
@@ -254,7 +254,18 @@ export interface TemplateContext {
          * @default `!(status >= 200 && status < 300)`
          */
         isErrorStatus?: string | ((status: number) => boolean);
-        /** if OperationObject["description"] is not defined but the main ResponseItem["description"] is defined, use the latter as ZodiosEndpointDescription["description"] */
+        /**
+         * when defined, will be used to pick the first MediaType found in (ResponseObject|RequestBodyObject)["content"] map matching the given expression
+         *
+         * context: some APIs returns multiple media types for the same response, this option allows you to pick which one to use
+         * or allows you to define a custom media type to use like `application/json-ld` or `application/vnd.api+json`) etc...
+         * @see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#response-object
+         * @see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#media-types
+         *
+         * @default `mediaType === "application/json"`
+         */
+        isMediaTypeAllowed?: string | ((mediaType: string) => boolean);
+        /** if OperationObject["description"] is not defined but the main ResponseObject["description"] is defined, use the latter as ZodiosEndpointDescription["description"] */
         useMainResponseDescriptionAsEndpointDescriptionFallback?: boolean;
         /**
          * when true, will export all `#/components/schemas` even when not used in any PathItemObject

--- a/src/template.hbs
+++ b/src/template.hbs
@@ -1,4 +1,4 @@
-import { asApi, Zodios } from "@zodios/core";
+import { makeApi, Zodios } from "@zodios/core";
 import { z } from "zod";
 
 {{#if types}}
@@ -17,7 +17,7 @@ const variables = {
 {{/each}}
 };
 
-const endpoints = asApi([
+const endpoints = makeApi([
 {{#each endpoints}}
 	{
 		method: "{{method}}",

--- a/tests/errors-responses.test.ts
+++ b/tests/errors-responses.test.ts
@@ -171,7 +171,7 @@ it.only("determines which status are considered errors-responses", async () => {
     });
 
     expect(result).toMatchInlineSnapshot(`
-      "import { asApi, Zodios } from "@zodios/core";
+      "import { makeApi, Zodios } from "@zodios/core";
       import { z } from "zod";
 
       const v0a43T4TEdB = z.enum(["aaa", "bbb", "ccc"]);
@@ -192,7 +192,7 @@ it.only("determines which status are considered errors-responses", async () => {
         getExample__2: vbpc7CyOzlu,
       };
 
-      const endpoints = asApi([
+      const endpoints = makeApi([
         {
           method: "get",
           path: "/example",
@@ -231,7 +231,7 @@ it.only("determines which status are considered errors-responses", async () => {
             openApiDoc,
         })
     ).toMatchInlineSnapshot(`
-      "import { asApi, Zodios } from "@zodios/core";
+      "import { makeApi, Zodios } from "@zodios/core";
       import { z } from "zod";
 
       const v0a43T4TEdB = z.enum(["aaa", "bbb", "ccc"]);
@@ -252,7 +252,7 @@ it.only("determines which status are considered errors-responses", async () => {
         getExample__2: vbpc7CyOzlu,
       };
 
-      const endpoints = asApi([
+      const endpoints = makeApi([
         {
           method: "get",
           path: "/example",

--- a/tests/is-main-response.test.ts
+++ b/tests/is-main-response.test.ts
@@ -42,7 +42,7 @@ it("determines which one is-main-response", async () => {
     });
 
     expect(result).toMatchInlineSnapshot(`
-      "import { asApi, Zodios } from "@zodios/core";
+      "import { makeApi, Zodios } from "@zodios/core";
       import { z } from "zod";
 
       const vssLgQd9tqs = z.object({ str: z.string(), nb: z.number() });
@@ -51,7 +51,7 @@ it("determines which one is-main-response", async () => {
         getExample: vssLgQd9tqs,
       };
 
-      const endpoints = asApi([
+      const endpoints = makeApi([
         {
           method: "get",
           path: "/example",

--- a/tests/is-media-type-allowed.test.ts
+++ b/tests/is-media-type-allowed.test.ts
@@ -1,0 +1,64 @@
+import { getZodiosEndpointDescriptionFromOpenApiDoc } from "../src";
+import { expect, test } from "vitest";
+import { OpenAPIObject } from "openapi3-ts";
+
+test("is-media-type-allowed", () => {
+    const doc: OpenAPIObject = {
+        openapi: "3.0.3",
+        info: { version: "1", title: "Example API" },
+        paths: {
+            "/unusual-ref-format": {
+                get: {
+                    operationId: "getWithUnusualRefFormat",
+                    responses: {
+                        "200": {
+                            content: {
+                                "application/json": { schema: { $ref: "#components/schemas/Basic" } },
+                                "application/json-ld": { schema: { $ref: "#components/schemas/CustomMediaType" } },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        components: {
+            schemas: {
+                Basic: { type: "string" },
+                CustomMediaType: { type: "number" },
+            },
+        },
+    };
+    const defaultResult = getZodiosEndpointDescriptionFromOpenApiDoc(doc);
+    expect(defaultResult.endpoints).toMatchInlineSnapshot(`
+      [
+          {
+              "alias": "getWithUnusualRefFormat",
+              "description": undefined,
+              "errors": [],
+              "method": "get",
+              "parameters": [],
+              "path": "/unusual-ref-format",
+              "requestFormat": "json",
+              "response": "@var/Basic",
+          },
+      ]
+    `);
+
+    const withCustomOption = getZodiosEndpointDescriptionFromOpenApiDoc(doc, {
+        isMediaTypeAllowed: (mediaType) => mediaType === "application/json-ld",
+    });
+    expect(withCustomOption.endpoints).toMatchInlineSnapshot(`
+      [
+          {
+              "alias": "getWithUnusualRefFormat",
+              "description": undefined,
+              "errors": [],
+              "method": "get",
+              "parameters": [],
+              "path": "/unusual-ref-format",
+              "requestFormat": "json",
+              "response": "@var/CustomMediaType",
+          },
+      ]
+    `);
+});

--- a/tests/main-description-as-fallback.test.ts
+++ b/tests/main-description-as-fallback.test.ts
@@ -40,7 +40,7 @@ it("use main-description-as-fallback", async () => {
     });
 
     expect(result).toMatchInlineSnapshot(`
-      "import { asApi, Zodios } from "@zodios/core";
+      "import { makeApi, Zodios } from "@zodios/core";
       import { z } from "zod";
 
       const vssLgQd9tqs = z.object({ str: z.string(), nb: z.number() });
@@ -49,7 +49,7 @@ it("use main-description-as-fallback", async () => {
         getExample: vssLgQd9tqs,
       };
 
-      const endpoints = asApi([
+      const endpoints = makeApi([
         {
           method: "get",
           path: "/example",

--- a/tests/recursive-schema.test.ts
+++ b/tests/recursive-schema.test.ts
@@ -138,7 +138,7 @@ describe("recursive-schema", () => {
         const prettyOutput = maybePretty(output, prettierConfig);
 
         expect(prettyOutput).toMatchInlineSnapshot(`
-          "import { asApi, Zodios } from "@zodios/core";
+          "import { makeApi, Zodios } from "@zodios/core";
           import { z } from "zod";
 
           type User = Partial<{
@@ -157,7 +157,7 @@ describe("recursive-schema", () => {
               getExample: vpPUiHrnAPA,
           };
 
-          const endpoints = asApi([
+          const endpoints = makeApi([
               {
                   method: "get",
                   path: "/example",
@@ -501,7 +501,7 @@ describe("recursive-schema", () => {
         const prettyOutput = maybePretty(output, prettierConfig);
 
         expect(prettyOutput).toMatchInlineSnapshot(`
-          "import { asApi, Zodios } from "@zodios/core";
+          "import { makeApi, Zodios } from "@zodios/core";
           import { z } from "zod";
 
           type UserWithFriends = Partial<{
@@ -530,7 +530,7 @@ describe("recursive-schema", () => {
               getExample: vJxvA6FpTFS,
           };
 
-          const endpoints = asApi([
+          const endpoints = makeApi([
               {
                   method: "get",
                   path: "/example",
@@ -636,7 +636,7 @@ describe("recursive-schema", () => {
         const output = template(data);
         const prettyOutput = maybePretty(output, prettierConfig);
         expect(prettyOutput).toMatchInlineSnapshot(`
-          "import { asApi, Zodios } from "@zodios/core";
+          "import { makeApi, Zodios } from "@zodios/core";
           import { z } from "zod";
 
           type Playlist = Partial<{
@@ -672,7 +672,7 @@ describe("recursive-schema", () => {
               getExample: vDYmM7qpXBP,
           };
 
-          const endpoints = asApi([
+          const endpoints = makeApi([
               {
                   method: "get",
                   path: "/example",


### PR DESCRIPTION
add `isMediaTypeAllowed` option

```
/**
         * when defined, will be used to pick the first MediaType found in (ResponseObject|RequestBodyObject)["content"] map matching the given expression
         *
         * context: some APIs returns multiple media types for the same response, this option allows you to pick which one to use
         * or allows you to define a custom media type to use like `application/json-ld` or `application/vnd.api+json`) etc...
         * @see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#response-object
         * @see https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#media-types
         *
         * @default `mediaType === "application/json"`
         */
        isMediaTypeAllowed?: string | ((mediaType: string) => boolean);
```