### PR TITLE
chore(gh-actions): initialize github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: CI
+
+on:
+    push:
+        branches: [main]
+        paths:
+            - src/**
+            - pnpm-lock.yaml
+            - package.json
+            - tsconfig.json
+    pull_request:
+        branches: [main]
+        paths:
+            - src/**
+            - pnpm-lock.yaml
+            - package.json
+            - tsconfig.json
+
+jobs:
+    build:
+        name: Build
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [14.x, 16.x, 18.x]
+                # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+            - name: Install pnpm
+              uses: pnpm/action-setup@v2
+              with:
+                  version: 7
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: "pnpm"
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+            - name: Build
+              run: pnpm build
+            - name: Test
+              run: pnpm test
+    analyze:
+        name: Analyze
+        runs-on: ubuntu-latest
+        permissions:
+            actions: read
+            contents: read
+            security-events: write
+        strategy:
+            fail-fast: false
+            matrix:
+                language: ["javascript"]
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v2
+              with:
+                  languages: ${{ matrix.language }}
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,62 @@
+# publish on npm when there is a new version tag
+
+name: publish
+on:
+    push:
+        tags: [v*]
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        strategy:
+            matrix:
+                node-version: [16.x]
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+            - name: Install pnpm
+              uses: pnpm/action-setup@v2
+              with:
+                  version: 7
+            - name: Use Node.js ${{ matrix.node-version }}
+              uses: actions/setup-node@v3
+              with:
+                  node-version: ${{ matrix.node-version }}
+                  cache: "pnpm"
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+            - name: Build
+              run: pnpm build
+            - name: Test
+              run: pnpm test
+            - name: Publish to npm
+              run: pnpm publish
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+            - name: generate changelog
+              uses: orhun/git-cliff-action@v1
+              id: cliff
+              with:
+                  args: --latest --strip footer
+              env:
+                  OUTPUT: CHANGES.md
+            - name: save changelog
+              id: changelog
+              shell: bash
+              run: |
+                  changelog=$(cat ${{ steps.cliff.outputs.changelog }})
+                  changelog="${changelog//'%'/'%25'}"
+                  changelog="${changelog//$'\n'/'%0A'}"
+                  changelog="${changelog//$'\r'/'%0D'}"
+                  echo "::set-output name=changelog::$changelog"
+            - name: create release
+              id: release
+              uses: actions/create-release@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  tag_name: ${{ github.ref }}
+                  release_name: Release ${{ github.ref }}
+                  body: ${{ steps.changelog.outputs.changelog }}
+                  draft: false
+                  prerelease: false


### PR DESCRIPTION
Hello alex,

I'm ready to help you. First thing, this PR is just to add github actions to automate your daily process :
- tests
- build
- publish

Note that publishing requires you to add a github secret named NPM_TOKEN else it wont work.
But it's really helpfull to automate this process.
You will gain a lot of time by doing this.

Automatic publish work by just adding a new tag.
so just doing : 
```bash
npm version <major|minor|patch>
git push --follow-tags
```

will create a new release automatically if the CI succeed.

Another thing, i propose to add (not this PR) is register a renovate bot. this will do all the maintainance for you. 
A lot of time gained from it.
But it as some consequences, like being spammed to update libs when new versions comes out.
So it's your choice