### PR TITLE
feat(error): add support for default error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: [14.x, 16.x, 18.x]
+                node-version: [16.x, 18.x]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
         steps:

--- a/src/__snapshots__/samples.test.ts.snap
+++ b/src/__snapshots__/samples.test.ts.snap
@@ -22,7 +22,22 @@ const variables = {
     postStreams: vLMDqDGAeww,
 };
 
-const endpoints = makeApi([]);
+const endpoints = makeApi([
+    {
+        method: "post",
+        path: "/streams",
+        description: \`subscribes a client to receive out-of-band data\`,
+        requestFormat: "json",
+        parameters: [
+            {
+                name: "callbackUrl",
+                type: "Query",
+                schema: z.string(),
+            },
+        ],
+        response: z.object({ subscriptionId: z.string() }),
+    },
+]);
 
 export const api = new Zodios(endpoints);
 "
@@ -132,6 +147,29 @@ const endpoints = makeApi([
         response: variables["pullrequest"],
     },
     {
+        method: "post",
+        path: "/2.0/repositories/:username/:slug/pullrequests/:pid/merge",
+        requestFormat: "json",
+        parameters: [
+            {
+                name: "username",
+                type: "Path",
+                schema: z.string(),
+            },
+            {
+                name: "slug",
+                type: "Path",
+                schema: z.string(),
+            },
+            {
+                name: "pid",
+                type: "Path",
+                schema: z.string(),
+            },
+        ],
+        response: z.void(),
+    },
+    {
         method: "get",
         path: "/2.0/users/:username",
         requestFormat: "json",
@@ -180,12 +218,26 @@ const endpoints = makeApi([
             },
         ],
         response: variables["Pets"],
+        errors: [
+            {
+                status: "default",
+                description: \`unexpected error\`,
+                schema: variables["Error"],
+            },
+        ],
     },
     {
         method: "post",
         path: "/pets",
         requestFormat: "json",
-        response: variables["Error"],
+        response: z.void(),
+        errors: [
+            {
+                status: "default",
+                description: \`unexpected error\`,
+                schema: variables["Error"],
+            },
+        ],
     },
     {
         method: "get",
@@ -199,6 +251,13 @@ const endpoints = makeApi([
             },
         ],
         response: variables["Pet"],
+        errors: [
+            {
+                status: "default",
+                description: \`unexpected error\`,
+                schema: variables["Error"],
+            },
+        ],
     },
 ]);
 
@@ -250,6 +309,13 @@ Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condime
             },
         ],
         response: z.array(variables["Pet"]),
+        errors: [
+            {
+                status: "default",
+                description: \`unexpected error\`,
+                schema: variables["Error"],
+            },
+        ],
     },
     {
         method: "post",
@@ -265,6 +331,13 @@ Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condime
             },
         ],
         response: variables["Pet"],
+        errors: [
+            {
+                status: "default",
+                description: \`unexpected error\`,
+                schema: variables["Error"],
+            },
+        ],
     },
     {
         method: "get",
@@ -279,6 +352,13 @@ Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condime
             },
         ],
         response: variables["Pet"],
+        errors: [
+            {
+                status: "default",
+                description: \`unexpected error\`,
+                schema: variables["Error"],
+            },
+        ],
     },
     {
         method: "delete",
@@ -292,7 +372,14 @@ Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condime
                 schema: z.number(),
             },
         ],
-        response: variables["Error"],
+        response: z.void(),
+        errors: [
+            {
+                status: "default",
+                description: \`unexpected error\`,
+                schema: variables["Error"],
+            },
+        ],
     },
 ]);
 

--- a/src/generateZodClientFromOpenAPI.test.ts
+++ b/src/generateZodClientFromOpenAPI.test.ts
@@ -225,23 +225,6 @@ test("getZodClientTemplateContext", async () => {
                   "response": "variables["Order"]",
               },
               {
-                  "alias": "createUser",
-                  "description": "This can only be done by the logged in user.",
-                  "errors": [],
-                  "method": "post",
-                  "parameters": [
-                      {
-                          "description": "Created user object",
-                          "name": "body",
-                          "schema": "variables["createUser_Body"]",
-                          "type": "Body",
-                      },
-                  ],
-                  "path": "/user",
-                  "requestFormat": "json",
-                  "response": "variables["User"]",
-              },
-              {
                   "alias": "getUserByName",
                   "description": "",
                   "errors": [
@@ -269,31 +252,15 @@ test("getZodClientTemplateContext", async () => {
                   "response": "variables["User"]",
               },
               {
-                  "alias": "updateUser",
-                  "description": "This can only be done by the logged in user.",
-                  "errors": [],
-                  "method": "put",
-                  "parameters": [
-                      {
-                          "description": "Update an existent user in the store",
-                          "name": "body",
-                          "schema": "variables["updateUser_Body"]",
-                          "type": "Body",
-                      },
-                      {
-                          "name": "username",
-                          "schema": "z.string()",
-                          "type": "Path",
-                      },
-                  ],
-                  "path": "/user/:username",
-                  "requestFormat": "json",
-                  "response": "z.void()",
-              },
-              {
                   "alias": "createUsersWithListInput",
                   "description": "Creates list of users with given input array",
-                  "errors": [],
+                  "errors": [
+                      {
+                          "description": "successful operation",
+                          "schema": "z.void()",
+                          "status": "default",
+                      },
+                  ],
                   "method": "post",
                   "parameters": [
                       {
@@ -333,16 +300,6 @@ test("getZodClientTemplateContext", async () => {
                   "path": "/user/login",
                   "requestFormat": "json",
                   "response": "z.string()",
-              },
-              {
-                  "alias": "logoutUser",
-                  "description": "",
-                  "errors": [],
-                  "method": "get",
-                  "parameters": [],
-                  "path": "/user/logout",
-                  "requestFormat": "json",
-                  "response": "z.void()",
               },
           ],
           "options": {
@@ -664,21 +621,6 @@ describe("generateZodClientFromOpenAPI", () => {
                   ],
               },
               {
-                  method: "post",
-                  path: "/user",
-                  description: \`This can only be done by the logged in user.\`,
-                  requestFormat: "json",
-                  parameters: [
-                      {
-                          name: "body",
-                          description: \`Created user object\`,
-                          type: "Body",
-                          schema: variables["createUser_Body"],
-                      },
-                  ],
-                  response: variables["User"],
-              },
-              {
                   method: "get",
                   path: "/user/:username",
                   requestFormat: "json",
@@ -704,26 +646,6 @@ describe("generateZodClientFromOpenAPI", () => {
                   ],
               },
               {
-                  method: "put",
-                  path: "/user/:username",
-                  description: \`This can only be done by the logged in user.\`,
-                  requestFormat: "json",
-                  parameters: [
-                      {
-                          name: "body",
-                          description: \`Update an existent user in the store\`,
-                          type: "Body",
-                          schema: variables["updateUser_Body"],
-                      },
-                      {
-                          name: "username",
-                          type: "Path",
-                          schema: z.string(),
-                      },
-                  ],
-                  response: z.void(),
-              },
-              {
                   method: "post",
                   path: "/user/createWithList",
                   description: \`Creates list of users with given input array\`,
@@ -736,6 +658,13 @@ describe("generateZodClientFromOpenAPI", () => {
                       },
                   ],
                   response: variables["User"],
+                  errors: [
+                      {
+                          status: "default",
+                          description: \`successful operation\`,
+                          schema: z.void(),
+                      },
+                  ],
               },
               {
                   method: "get",
@@ -761,12 +690,6 @@ describe("generateZodClientFromOpenAPI", () => {
                           schema: z.void(),
                       },
                   ],
-              },
-              {
-                  method: "get",
-                  path: "/user/logout",
-                  requestFormat: "json",
-                  response: z.void(),
               },
           ]);
 
@@ -1056,22 +979,6 @@ describe("generateZodClientFromOpenAPI", () => {
                   ],
               },
               {
-                  method: "post",
-                  path: "/user",
-                  alias: "createUser",
-                  description: \`This can only be done by the logged in user.\`,
-                  requestFormat: "json",
-                  parameters: [
-                      {
-                          name: "body",
-                          description: \`Created user object\`,
-                          type: "Body",
-                          schema: variables["createUser_Body"],
-                      },
-                  ],
-                  response: variables["User"],
-              },
-              {
                   method: "get",
                   path: "/user/:username",
                   alias: "getUserByName",
@@ -1098,27 +1005,6 @@ describe("generateZodClientFromOpenAPI", () => {
                   ],
               },
               {
-                  method: "put",
-                  path: "/user/:username",
-                  alias: "updateUser",
-                  description: \`This can only be done by the logged in user.\`,
-                  requestFormat: "json",
-                  parameters: [
-                      {
-                          name: "body",
-                          description: \`Update an existent user in the store\`,
-                          type: "Body",
-                          schema: variables["updateUser_Body"],
-                      },
-                      {
-                          name: "username",
-                          type: "Path",
-                          schema: z.string(),
-                      },
-                  ],
-                  response: z.void(),
-              },
-              {
                   method: "post",
                   path: "/user/createWithList",
                   alias: "createUsersWithListInput",
@@ -1132,6 +1018,13 @@ describe("generateZodClientFromOpenAPI", () => {
                       },
                   ],
                   response: variables["User"],
+                  errors: [
+                      {
+                          status: "default",
+                          description: \`successful operation\`,
+                          schema: z.void(),
+                      },
+                  ],
               },
               {
                   method: "get",
@@ -1158,13 +1051,6 @@ describe("generateZodClientFromOpenAPI", () => {
                           schema: z.void(),
                       },
                   ],
-              },
-              {
-                  method: "get",
-                  path: "/user/logout",
-                  alias: "logoutUser",
-                  requestFormat: "json",
-                  response: z.void(),
               },
           ]);
 
@@ -1445,21 +1331,6 @@ describe("generateZodClientFromOpenAPI", () => {
                   ],
               },
               {
-                  method: "post",
-                  path: "/user",
-                  description: \`This can only be done by the logged in user.\`,
-                  requestFormat: "json",
-                  parameters: [
-                      {
-                          name: "body",
-                          description: \`Created user object\`,
-                          type: "Body",
-                          schema: variables["createUser_Body"],
-                      },
-                  ],
-                  response: variables["User"],
-              },
-              {
                   method: "get",
                   path: "/user/:username",
                   requestFormat: "json",
@@ -1485,26 +1356,6 @@ describe("generateZodClientFromOpenAPI", () => {
                   ],
               },
               {
-                  method: "put",
-                  path: "/user/:username",
-                  description: \`This can only be done by the logged in user.\`,
-                  requestFormat: "json",
-                  parameters: [
-                      {
-                          name: "body",
-                          description: \`Update an existent user in the store\`,
-                          type: "Body",
-                          schema: variables["updateUser_Body"],
-                      },
-                      {
-                          name: "username",
-                          type: "Path",
-                          schema: z.string(),
-                      },
-                  ],
-                  response: z.void(),
-              },
-              {
                   method: "post",
                   path: "/user/createWithList",
                   description: \`Creates list of users with given input array\`,
@@ -1517,6 +1368,13 @@ describe("generateZodClientFromOpenAPI", () => {
                       },
                   ],
                   response: variables["User"],
+                  errors: [
+                      {
+                          status: "default",
+                          description: \`successful operation\`,
+                          schema: z.void(),
+                      },
+                  ],
               },
               {
                   method: "get",
@@ -1542,12 +1400,6 @@ describe("generateZodClientFromOpenAPI", () => {
                           schema: z.void(),
                       },
                   ],
-              },
-              {
-                  method: "get",
-                  path: "/user/logout",
-                  requestFormat: "json",
-                  response: z.void(),
               },
           ]);
 

--- a/src/generateZodClientFromOpenAPI.ts
+++ b/src/generateZodClientFromOpenAPI.ts
@@ -1,4 +1,4 @@
-import { compile } from "handlebars";
+import { compile, registerHelper, HelperOptions } from "handlebars";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { OpenAPIObject } from "openapi3-ts";
@@ -19,6 +19,15 @@ import { topologicalSort } from "./topologicalSort";
 const file = ts.createSourceFile("", "", ts.ScriptTarget.ESNext, true);
 const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
 const printTs = (node: ts.Node) => printer.printNode(ts.EmitHint.Unspecified, node, file);
+
+registerHelper("ifeq", function (a: string, b: string, options: HelperOptions) {
+    if (a === b) {
+        // @ts-ignore
+        return options.fn(this);
+    }
+    // @ts-ignore
+    return options.inverse(this);
+});
 
 export const getZodClientTemplateContext = (
     openApiDoc: GenerateZodClientFromOpenApiArgs["openApiDoc"],

--- a/src/getZodiosEndpointDefinitionFromOpenApiDoc.test.ts
+++ b/src/getZodiosEndpointDefinitionFromOpenApiDoc.test.ts
@@ -871,7 +871,13 @@ test("petstore.yaml", async () => {
               {
                   "alias": "createUser",
                   "description": "This can only be done by the logged in user.",
-                  "errors": [],
+                  "errors": [
+                      {
+                          "description": "successful operation",
+                          "schema": "@var/User",
+                          "status": "default",
+                      },
+                  ],
                   "method": "post",
                   "parameters": [
                       {
@@ -883,12 +889,17 @@ test("petstore.yaml", async () => {
                   ],
                   "path": "/user",
                   "requestFormat": "json",
-                  "response": "@var/User",
               },
               {
                   "alias": "createUsersWithListInput",
                   "description": "Creates list of users with given input array",
-                  "errors": [],
+                  "errors": [
+                      {
+                          "description": "successful operation",
+                          "schema": "z.void()",
+                          "status": "default",
+                      },
+                  ],
                   "method": "post",
                   "parameters": [
                       {
@@ -932,12 +943,17 @@ test("petstore.yaml", async () => {
               {
                   "alias": "logoutUser",
                   "description": "",
-                  "errors": [],
+                  "errors": [
+                      {
+                          "description": "successful operation",
+                          "schema": "z.void()",
+                          "status": "default",
+                      },
+                  ],
                   "method": "get",
                   "parameters": [],
                   "path": "/user/logout",
                   "requestFormat": "json",
-                  "response": "z.void()",
               },
               {
                   "alias": "getUserByName",
@@ -969,7 +985,13 @@ test("petstore.yaml", async () => {
               {
                   "alias": "updateUser",
                   "description": "This can only be done by the logged in user.",
-                  "errors": [],
+                  "errors": [
+                      {
+                          "description": "successful operation",
+                          "schema": "z.void()",
+                          "status": "default",
+                      },
+                  ],
                   "method": "put",
                   "parameters": [
                       {
@@ -986,7 +1008,6 @@ test("petstore.yaml", async () => {
                   ],
                   "path": "/user/:username",
                   "requestFormat": "json",
-                  "response": "z.void()",
               },
               {
                   "alias": "deleteUser",

--- a/src/getZodiosEndpointDefinitionFromOpenApiDoc.ts
+++ b/src/getZodiosEndpointDefinitionFromOpenApiDoc.ts
@@ -193,7 +193,7 @@ export const getZodiosEndpointDefinitionFromOpenApiDoc = (doc: OpenAPIObject, op
                 if (schemaString) {
                     const status = Number(statusCode);
 
-                    if (isMainResponseStatus(status) || (statusCode === "default" && !endpointDescription.response)) {
+                    if (!isErrorStatus(status)) {
                         // if we want `response: variables["listPets"]`, instead of `response: variables["Pets"]`,
                         // getZodVarName should use operation.operationId as fallbackName
                         endpointDescription.response = schemaString;
@@ -205,10 +205,10 @@ export const getZodiosEndpointDefinitionFromOpenApiDoc = (doc: OpenAPIObject, op
                         ) {
                             endpointDescription.description = responseItem.description;
                         }
-                    } else if (statusCode !== "default" && isErrorStatus(status)) {
+                    } else if (statusCode === "default" || isErrorStatus(status)) {
                         endpointDescription.errors.push({
                             schema: schemaString as any,
-                            status,
+                            status: statusCode === "default" ? "default" : status,
                             description: responseItem.description,
                         });
                     }

--- a/src/template.hbs
+++ b/src/template.hbs
@@ -54,7 +54,11 @@ const endpoints = makeApi([
 		errors: [
 			{{#each errors}}
 			{
+				{{#ifeq status "default" }}
+				status: "default",
+				{{else}}
 				status: {{status}},
+				{{/ifeq}}
 				{{#if description}}
 				description: `{{description}}`,
 				{{/if}}

--- a/tests/errors-responses.test.ts
+++ b/tests/errors-responses.test.ts
@@ -69,7 +69,7 @@ it("includes errors-responses", async () => {
           method: "get",
           path: "/example",
           requestFormat: "json",
-          response: z.object({ str: z.string(), nb: z.number() }),
+          response: z.number(),
           errors: [
             {
               status: 400,
@@ -197,7 +197,9 @@ it("determines which status are considered errors-responses", async () => {
           method: "get",
           path: "/example",
           requestFormat: "json",
-          response: z.object({ str: z.string(), nb: z.number() }),
+          response: z
+            .object({ is400: z.boolean(), nested: variables["getExample"] })
+            .partial(),
           errors: [
             {
               status: 400,
@@ -257,7 +259,9 @@ it("determines which status are considered errors-responses", async () => {
           method: "get",
           path: "/example",
           requestFormat: "json",
-          response: z.object({ str: z.string(), nb: z.number() }),
+          response: z
+            .object({ is400: z.boolean(), nested: variables["getExample"] })
+            .partial(),
           errors: [
             {
               status: 400,


### PR DESCRIPTION
Hello Alex,

With this pull request i'm adding support for default errors. indeed zodios also has default errors.

This also seems to fix a bug where only other than '200' ok code would not emit response type.

now the `/samples/3.0/petstore.yaml` convertion will output correct zodios api definition.

I added a handlebar helper to handle this use case. tell me if it's ok for you.