### PR TITLE
Fix unhandled default values for "array" type

### DIFF
--- a/.changeset/four-parents-type.md
+++ b/.changeset/four-parents-type.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": patch
+---
+
+Fixes and issue where default values for arrays are incorrectly set (or ommited) in the zod schema.

--- a/lib/src/openApiToZod.ts
+++ b/lib/src/openApiToZod.ts
@@ -257,6 +257,7 @@ const getZodChainableDefault = (schema: SchemaObject) => {
     if (schema.default) {
         const value = match(schema.type)
             .with("number", "integer", () => unwrapQuotesIfNeeded(schema.default))
+            .with("array", () => JSON.stringify(schema.default))
             .otherwise(() => (typeof schema.default === "string" ? `"${schema.default}"` : schema.default));
         return `default(${value})`;
     }

--- a/lib/tests/array-default-values.test.ts
+++ b/lib/tests/array-default-values.test.ts
@@ -1,0 +1,170 @@
+import type { OpenAPIObject } from "openapi3-ts";
+import { expect, test } from "vitest";
+import { generateZodClientFromOpenAPI } from "../src";
+
+// https://github.com/astahmer/openapi-zod-client/issues/61
+test("array-default-values", async () => {
+    const openApiDoc: OpenAPIObject = {
+        openapi: "3.0.0",
+        info: {
+            version: "1.0.0",
+            title: "enums min max",
+        },
+        paths: {
+            "/sample": {
+                get: {
+                    parameters: [
+                        {
+                            in: "query",
+                            name: "array-empty",
+                            schema: {
+                                type: "array",
+                                items: { type: "string" },
+                                default: [],
+                            },
+                        },
+                        {
+                            in: "query",
+                            name: "array-string",
+                            schema: {
+                                type: "array",
+                                items: { type: "string" },
+                                default: ["one", "two"],
+                            },
+                        },
+                        {
+                            in: "query",
+                            name: "array-number",
+                            schema: {
+                                type: "array",
+                                items: { type: "number" },
+                                default: [1, 2],
+                            },
+                        },
+                        {
+                            in: "query",
+                            name: "array-object",
+                            schema: {
+                                type: "array",
+                                items: { type: "object", properties: { foo: { type: "string" } } },
+                                default: [{ foo: "bar" }],
+                            },
+                        },
+                        {
+                            in: "query",
+                            name: "array-ref-object",
+                            schema: {
+                                type: "array",
+                                items: { $ref: "#/components/schemas/MyComponent" },
+                                default: [{ id: 1, name: "foo" }],
+                            },
+                        },
+                        {
+                            in: "query",
+                            name: "array-ref-enum",
+                            schema: {
+                                type: "array",
+                                items: { $ref: "#/components/schemas/MyEnum" },
+                                default: ["one", "two"],
+                            },
+                        },
+                    ],
+                    responses: {
+                        "200": {
+                            description: "resoponse",
+                        },
+                    },
+                },
+            },
+        },
+        components: {
+            schemas: {
+                MyComponent: {
+                    type: "object",
+                    properties: {
+                        id: {
+                            type: "number",
+                        },
+                        name: {
+                            type: "string",
+                        },
+                    },
+                },
+                MyEnum: {
+                    type: "string",
+                    enum: ["one", "two", "three"],
+                },
+            },
+        },
+    };
+
+    const output = await generateZodClientFromOpenAPI({ disableWriteToFile: true, openApiDoc });
+    expect(output).toMatchInlineSnapshot(`
+      "import { makeApi, Zodios, type ZodiosOptions } from "@zodios/core";
+      import { z } from "zod";
+
+      const array_object = z
+        .array(z.object({ foo: z.string() }).partial())
+        .optional()
+        .default([{ foo: "bar" }]);
+      const MyComponent = z.object({ id: z.number(), name: z.string() }).partial();
+      const MyEnum = z.enum(["one", "two", "three"]);
+
+      export const schemas = {
+        array_object,
+        MyComponent,
+        MyEnum,
+      };
+      
+      const endpoints = makeApi([
+        {
+          method: "get",
+          path: "/sample",
+          requestFormat: "json",
+          parameters: [
+            {
+              name: "array-empty",
+              type: "Query",
+              schema: z.array(z.string()).optional().default([]),
+            },
+            {
+              name: "array-string",
+              type: "Query",
+              schema: z.array(z.string()).optional().default(["one", "two"]),
+            },
+            {
+              name: "array-number",
+              type: "Query",
+              schema: z.array(z.number()).optional().default([1, 2]),
+            },
+            {
+              name: "array-object",
+              type: "Query",
+              schema: array_object,
+            },
+            {
+              name: "array-ref-object",
+              type: "Query",
+              schema: z
+                .array(MyComponent)
+                .optional()
+                .default([{ id: 1, name: "foo" }]),
+            },
+            {
+              name: "array-ref-enum",
+              type: "Query",
+              schema: z.array(MyEnum).optional().default(["one", "two"]),
+            },
+          ],
+          response: z.void(),
+        },
+      ]);
+
+      export const api = new Zodios(endpoints);
+
+      export function createApiClient(baseUrl: string, options?: ZodiosOptions) {
+        return new Zodios(baseUrl, endpoints, options);
+      }
+      "
+    `);
+});


### PR DESCRIPTION
The "array" type got forgotten in `getZodChainableDefault`, resulting in a breaking output for any array with default values, [as reproduced here](https://openapi-zod-client.vercel.app/?doc=N4KABGBED2AOCmA7AhrAlpAXFAzAOgAZDIAacKNRAM2izFAgkgDd4AnAZzWkTsgEZCxMoygAXNGIA28PkgCuAWw5hFlVcgAekcgF8RUWMjEALDnQaNIAeg7JFsGRfKjIAc3hjno10bb3PdnNsAG0XHwhLCNdKPgBHeXYAT1Jw6KgURVlsSGQ2fySAWngHMRSDdKYOAGMTEuRvStcyhD48gtSmmLES4Po0rsgW7KgOMTZKNx0uxn0B9MgAE3gqZHkpL1CAXXmfXV2IOaaoyshYnITkzsHMkdz85CKxicQpitOausUG7BOmoaSrRy7Ue1xmZx6ykaMyYwz4z0m0xhRxhSxWaw2dDCMKsPFk73BYgA7rQDj4djN9k0Uek-tEzrwLok2OUyUxbm0HkVEEoAEbsMEfWr1aGDOHArmC-6SXqiwmAu48xT8thIykE07LVbrTZgbE4sD8DVNABMbMYFK6VMqNOidIiDPizNZ4I5EoKhWgvIAVvBql5jT5IJ8Rb9zbCFZyOoGHTKoWGDeJIzkvb7-VLBrA2HB2BJ4H17YMaLQE4mrOLRuNEeG9jXDjXbf8tRjdfqcYX-sW%2BLy8mrkTXLdSyY2fB2rOcoJcWRmHW6oCCimwVp6fX6A%2Bbg8LvnLThX7tGaxDZaWcZAACRLqh8ADE1mq0AceMQYg4ti3yFfAFkkgBhB%2BwJ8vAbGMg2bHUsTrfoywoRY6CNSD2QCPgu0g60ZkHG1hxAscmAnSApxdG4kPdR5CkvYolRnIMQ23E8xWTedJRA7pjygg1z0vG873-QDXxoj9rG-ABRSjgMPMDMVCSCYEQfFpOJUkcQw9I0OiVTRC2QNICXDgAMQDh8x3VwTQIAgjNA-NqgmWAJB4PgdLgHgDL7CJ1NmAZVOtFFIHvR9ZOfAtwk3L4Px3SBvz-PykF1QsASBKBUzXKjICzHM2DzQLpVguiFj3JUVRcvYQMgOccKTeLgyrV5CtENz61cjVwqSESlHMuK7gRaqtIURQIP%2BPEqNhElBvEEwl1kXZlLATy9BAXQgA).

This PR adds a naïve `JSON.stringify` for array defaults, but it seems to be fixing all of the cases in the repro (see added test).