### PR TITLE
Fix empty schema when allOf contains a single ref (also oneOf, anyOf)

### DIFF
--- a/lib/src/openApiToZod.ts
+++ b/lib/src/openApiToZod.ts
@@ -81,7 +81,8 @@ export function getZodSchema({ schema, ctx, meta: inheritedMeta, options }: Conv
 
     if (schema.oneOf) {
         if (schema.oneOf.length === 1) {
-            return getZodSchema({ schema: schema.oneOf[0]!, ctx, meta, options });
+            const type = getZodSchema({ schema: schema.oneOf[0]!, ctx, meta, options });
+            return code.assign(type.toString());
         }
 
         return code.assign(
@@ -92,7 +93,8 @@ export function getZodSchema({ schema, ctx, meta: inheritedMeta, options }: Conv
     // anyOf = oneOf but with 1 or more = `T extends oneOf ? T | T[] : never`
     if (schema.anyOf) {
         if (schema.anyOf.length === 1) {
-            return getZodSchema({ schema: schema.anyOf[0]!, ctx, meta, options });
+            const type = getZodSchema({ schema: schema.anyOf[0]!, ctx, meta, options });
+            return code.assign(type.toString());
         }
 
         const types = schema.anyOf.map((prop) => getZodSchema({ schema: prop, ctx, meta, options })).join(", ");
@@ -102,7 +104,8 @@ export function getZodSchema({ schema, ctx, meta: inheritedMeta, options }: Conv
 
     if (schema.allOf) {
         if (schema.allOf.length === 1) {
-            return getZodSchema({ schema: schema.allOf[0]!, ctx, meta, options });
+            const type = getZodSchema({ schema: schema.allOf[0]!, ctx, meta, options });
+            return code.assign(type.toString());
         }
 
         const types = schema.allOf.map((prop) => getZodSchema({ schema: prop, ctx, meta, options }));

--- a/lib/tests/allOf-oneOf-anyOf-single-ref.test.ts
+++ b/lib/tests/allOf-oneOf-anyOf-single-ref.test.ts
@@ -1,0 +1,99 @@
+import type { OpenAPIObject } from "openapi3-ts";
+import { expect, test } from "vitest";
+import { generateZodClientFromOpenAPI } from "../src";
+
+// https://github.com/astahmer/openapi-zod-client/issues/49
+test("allOf-single-ref", async () => {
+    const openApiDoc: OpenAPIObject = {
+        openapi: "3.0.2",
+        info: {
+            title: "allOf single ref",
+            version: "v1",
+        },
+        paths: {
+            "/test": {
+                get: {
+                    parameters: [
+                        {
+                            name: "allOf_ref_param",
+                            schema: {
+                                allOf: [{ $ref: "#/components/schemas/MyComponent" }],
+                            },
+                            in: "query",
+                        },
+                        {
+                            name: "oneOf_ref_param",
+                            schema: {
+                                oneOf: [{ $ref: "#/components/schemas/MyComponent" }],
+                            },
+                            in: "query",
+                        },
+                        {
+                            name: "anyOf_ref_param",
+                            schema: {
+                                anyOf: [{ $ref: "#/components/schemas/MyComponent" }],
+                            },
+                            in: "query",
+                        },
+                    ],
+                },
+            },
+        },
+        components: {
+            schemas: {
+                MyComponent: {
+                    title: "MyComponent",
+                    enum: ["one", "two", "three"],
+                    type: "string",
+                },
+            },
+        },
+    };
+
+    const output = await generateZodClientFromOpenAPI({ disableWriteToFile: true, openApiDoc });
+    expect(output).toMatchInlineSnapshot(`
+      "import { makeApi, Zodios, type ZodiosOptions } from "@zodios/core";
+      import { z } from "zod";
+
+      const MyComponent = z.enum(["one", "two", "three"]);
+      const allOf_ref_param = MyComponent.optional();
+      
+      export const schemas = {
+        MyComponent,
+        allOf_ref_param,
+      };
+      
+      const endpoints = makeApi([
+        {
+          method: "get",
+          path: "/test",
+          requestFormat: "json",
+          parameters: [
+            {
+              name: "allOf_ref_param",
+              type: "Query",
+              schema: allOf_ref_param,
+            },
+            {
+              name: "oneOf_ref_param",
+              type: "Query",
+              schema: allOf_ref_param,
+            },
+            {
+              name: "anyOf_ref_param",
+              type: "Query",
+              schema: allOf_ref_param,
+            },
+          ],
+          response: z.void(),
+        },
+      ]);
+      
+      export const api = new Zodios(endpoints);
+      
+      export function createApiClient(baseUrl: string, options?: ZodiosOptions) {
+        return new Zodios(baseUrl, endpoints, options);
+      }
+      "
+    `);
+});


### PR DESCRIPTION
[Reproduction here](https://openapi-zod-client.vercel.app/?doc=N4KABGBED2AOCmA7AhrAlpAXFAzAOgAY8AmSAGnCjUQDNosxQIJIAXNVgG3gbfgGdWYZJ04B5GmH7UA5tzAAneDXKUWAN3gLp0RL3UBGSJQC%2BFFrGSsAFvwZNmLAPSsBre2sfNIM%2BO%2BwOXkFQlgrIALZ%2BWnbYANqewV6BiV6QKJG8IuI0APpKuaERqinBkPwAxtbw4cgeJYmQWRIM8fUpwFAAJPm8AMRO5dDhsLpIrPxOFVU1EwCyAJ4AwkMjiGOQYCYJbWAAutslZgcpkNS8AI4Arlrzxjub5jvJbWkRPNgwaxJ5yjmF4cV7lAptVagFjiVPvBmnEIfUOpBuso%2BgMVqNEONJpVQXMlmi1hiNlsgcx9iSjiTTnoPlcbncdhSnnCgq8Mh9kIh5t98n9kGEAY97mVsTU6iSoByuSpYeLmAikdKoP1BsN0ZiQTMnAtlqqCe5NszgmSgYyhWcadcFLdDRATMbEsSvI7GZAVasxjFGJ5hdNkJ7nlBtfj1uDIewuO9A3jdetBaUkJcAXEoeQoKwAO70Mhp6xKHi7OMs1jzBC8QQKWT0xyO22mEAmIA)
When `allOf` has a single entry that is a ref, the schema fails generating:

Input:
```
"parameters": [
        {
        "name": "allOf_ref_param",
        "schema": {
          "allOf": [
            { "$ref": "#/components/schemas/MyComponent" }
          ]
        },
        "in": "query"
      },
```

Output:
```
parameters: [
	{
		name: "allOf_ref_param",
		type: "Query",
		schema: 
	},
```

same with `oneOf`, `anyOf`