### PR TITLE
fix: default values for "object" type

### DIFF
--- a/.changeset/brown-coins-hunt.md
+++ b/.changeset/brown-coins-hunt.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": patch
+---
+
+Fixes and issue where default values for objects are incorrectly set (or ommited) in the zod schema.

--- a/lib/src/openApiToZod.ts
+++ b/lib/src/openApiToZod.ts
@@ -260,7 +260,7 @@ const getZodChainableDefault = (schema: SchemaObject) => {
     if (schema.default) {
         const value = match(schema.type)
             .with("number", "integer", () => unwrapQuotesIfNeeded(schema.default))
-            .with("array", () => JSON.stringify(schema.default))
+            .with("array", "object", () => JSON.stringify(schema.default))
             .otherwise(() => (typeof schema.default === "string" ? `"${schema.default}"` : schema.default));
         return `default(${value})`;
     }

--- a/lib/tests/object-default-values.test.ts
+++ b/lib/tests/object-default-values.test.ts
@@ -1,0 +1,121 @@
+import type { OpenAPIObject } from "openapi3-ts";
+import { expect, test } from "vitest";
+import { generateZodClientFromOpenAPI } from "../src";
+
+// https://github.com/astahmer/openapi-zod-client/issues/61
+test("object-default-values", async () => {
+    const openApiDoc: OpenAPIObject = {
+        openapi: "3.0.0",
+        info: {
+            version: "1.0.0",
+            title: "object default values",
+        },
+        paths: {
+            "/sample": {
+                get: {
+                    parameters: [
+                        {
+                            in: "query",
+                            name: "empty-object",
+                            schema: {
+                                type: "object",
+                                properties: { foo: { type: "string" } },
+                                default: {},
+                            },
+                        },
+                        {
+                            in: "query",
+                            name: "default-object",
+                            schema: {
+                                type: "object",
+                                properties: { foo: { type: "string" } },
+                                default: { foo: "bar" },
+                            },
+                        },
+                        {
+                            in: "query",
+                            name: "ref-object",
+                            schema: {
+                                type: "object",
+                                additionalProperties: { $ref: "#/components/schemas/MyComponent" },
+                                default: { id: 1, name: "foo" },
+                            },
+                        },
+                    ],
+                    responses: {
+                        "200": {
+                            description: "resoponse",
+                        },
+                    },
+                },
+            },
+        },
+        components: {
+            schemas: {
+                MyComponent: {
+                    type: "object",
+                    properties: {
+                        id: {
+                            type: "number",
+                        },
+                        name: {
+                            type: "string",
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    const output = await generateZodClientFromOpenAPI({ disableWriteToFile: true, openApiDoc });
+    expect(output).toMatchInlineSnapshot(`
+      "import { makeApi, Zodios, type ZodiosOptions } from "@zodios/core";
+      import { z } from "zod";
+
+      const MyComponent = z.object({ id: z.number(), name: z.string() }).partial();
+
+      export const schemas = {
+        MyComponent,
+      };
+      
+      const endpoints = makeApi([
+        {
+          method: "get",
+          path: "/sample",
+          requestFormat: "json",
+          parameters: [
+            {
+              name: "empty-object",
+              type: "Query",
+              schema: z.object({ foo: z.string() }).partial().optional().default({}),
+            },
+            {
+              name: "default-object",
+              type: "Query",
+              schema: z
+                .object({ foo: z.string() })
+                .partial()
+                .optional()
+                .default({ foo: "bar" }),
+            },
+            {
+              name: "ref-object",
+              type: "Query",
+              schema: z
+                .record(MyComponent)
+                .optional()
+                .default({ id: 1, name: "foo" }),
+            },
+          ],
+          response: z.void(),
+        },
+      ]);
+
+      export const api = new Zodios(endpoints);
+
+      export function createApiClient(baseUrl: string, options?: ZodiosOptions) {
+        return new Zodios(baseUrl, endpoints, options);
+      }
+      "
+    `);
+});


### PR DESCRIPTION
Just as for "array" type default values in PR #86, this fixes default values for "object" type.

[Repro here](https://openapi-zod-client.vercel.app/?doc=N4KABGBED2AOCmA7AhrAlpAXFAzAOgAZDIAacKNRAM2izFAgkgDd4AnAZzWkTsgEZCxMoygAXNGIA28PtABGAK3gBjMWAAm8KsgCuU9c2RTd8DpHIBfEVFjIxAC3PYGjSAHoOyALawZdV1FIAHN4MQDyUSY7Nh8w9mcwAG1IqIhAtLdKPgBHUzYAT1JUzKgUb1lsSHhfMQKAWgVlNWLSoI4VBxrkCLaoyDqEOSVVcJs%2B6LY4dgkzXomgmloXEoXxAqGqjjE2SmCLNcZLVdLrE8zILR19cJdjhfu2s76M0shsqrz2IvG2yHLKlArnoDI0Ri1fm8Ol1vD0VocBhtATBwWNzmlILApgg2LNEq8JpAlvNDkxBsjtrtEPt0ZlHg9IX9gTcSWsidBllB5Mg2Ac1vSnrTnm0CRiPlAvoVWoSAXw2Nowc00QtINDuqy%2BojNlAmqNpSrkBoNJJuCgpAAFbEzNBzeGkyAAEnlVD4AGJ3CpoL4eEgxBxPJ1uv6ALIFADCXtgPsQ4VpomFKuZBg1hLQGjo-EZmtlVWJcaO%2BYFaSLjAAulmoPKOFHEBxbfRaZAAEwEAgpjFaDq7WASHhysxwHh1vmnc4lgWPYWQT3exC%2B-GpVWB2ELjGhiOz33t9balFK-X9LHTXE21d-NPboLkviIXTeeTsEd0itMHMNlXXrY7PZP4tj1YTlYICWEAA&prettier=EQbwOgdgBDVsAHATgSwgFwOooCboBbwBcUAjAEwAMANJLHMOgIYBG2ehwJALLdLPCZIkAewDuABSEBTCAGdiDJgBsxTAJ4LgfevACuc6QBVWWkgDMVhnQOCGAtikXoke6TZjw5aAObLpAIp6IujSipbK1nS2Lkwoyr4AwiL29kyK8NJyAKzwkAC%2BwEA)