### PR TITLE
fix: enum with a single member should not generate a zod union

### DIFF
--- a/.changeset/chilled-rats-begin.md
+++ b/.changeset/chilled-rats-begin.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": patch
+---
+
+Fixed an issue with non-string enums containing a single value, resulting in an invalid zod union

--- a/lib/src/openApiToZod.test.ts
+++ b/lib/src/openApiToZod.test.ts
@@ -105,6 +105,7 @@ test("getSchemaAsZodString", () => {
     expect(getSchemaAsZodString({ type: "number", enum: [1, 2, 3, null] })).toMatchInlineSnapshot(
         '"z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(null)])"'
     );
+    expect(getSchemaAsZodString({ type: "number", enum: [1] })).toMatchInlineSnapshot('"z.literal(1)"');
 });
 
 test("getSchemaWithChainableAsZodString", () => {

--- a/lib/src/openApiToZod.ts
+++ b/lib/src/openApiToZod.ts
@@ -130,6 +130,11 @@ export function getZodSchema({ schema, ctx, meta: inheritedMeta, options }: Conv
                 return code.assign("z.never()");
             }
 
+            if (schema.enum.length === 1) {
+                const value = schema.enum[0];
+                return code.assign(`z.literal(${value === null ? "null" : value})`);
+            }
+
             return code.assign(
                 // eslint-disable-next-line sonarjs/no-nested-template-literals
                 `z.union([${schema.enum.map((value) => `z.literal(${value === null ? "null" : value})`).join(", ")}])`


### PR DESCRIPTION
`{ type: "number", enum: [2] }` results in `z.union([z.literal(2)])`, which is invalid as `z.union` requires at least two union members. 
The result should just be `z.literal(2)` instead.

[Reproduction here](https://openapi-zod-client.vercel.app/?doc=N4KABBYEQPYA4FMB2BDOBLKAuaBmAdAAxFQA04kU6SAZjNmKJM9AG4IBOAzujEg1ACMREuRaUALugkAbBAIDKAdxQBzVZzAAFBBK4SYHeWPHQZ6AMbIu8nE1PMoqALa3oAWQCSAFSgVxAL7%2BYAEmEFA2HOzcDADawcz2DuEArhwyAgAWEhJwWAD0%2BYh6Bkb4XCrqnPi8%2BayCfg5BzAC6YdBwKBKZXAxJLFBFur12CaZQGhJ9Y8nQXCnOzigcAJ4CADLo%2BmAoMjJgxb3ts%2BHwnF28SJ4AJgLm%2Bjp6ZDPJUBJqI2CxUIdQbS8OH7LFCuCScT7xE7JfpQwEuNxQczOaTPWEnKj8HBQACOKU4a2OaIG1wQXAsHHQcCkfAEAAkYEowEskCswNIEM4uGADGAjBI0kgdhIwHwENz0K4wAAKJYADzAgkIhAAlKiiYCjLj0EZbjgaLsbIT1eEyZkOShpsb0RIVogBNQwRoOGqrYC6BwllMsQ7cAAmRqu5jNV2hAEnYDQeECHhIGQaMDIBZkaDUAS4-HJiIWM1LPpvW22JwLABGnEzieccV9LQCwbR-3VUCMXDgfBsnxhRKgvqVlsDlBJZIpVMuAgAggc1AhrjsOBwUKyYDQDsMXf2oGaUCSYqN%2B%2BNZQBaJAIWVexhhvdQQfkynUzHQCfmJAAa25MG5ZrAx9Pk-jS95pKtkg7Zrnu4hZjmFq7mBUL5naWL6BSSCqAGMGBBexp1v2oYwVAFh8GCSBnp2l5oHA5gWBcfD5AAVlwNLQWhAymuafZMYCAAkRg0AIADE%2BT4c4QHIHo%2BQsUsXD5I8vQYYGWEwfJIayaYOGuleCD6ikMjEcpszqUOt6jliKTfogFhgjOnAcIYoFqfhREiWxaFQGRFFUUgtH0feJHOeJUHnuxrxcRpfECTAQmikRkl%2BZJACic42bpmFJVCilWmlsIZU0GGqXprb6E5sHzIsyxrFiADCRhdGKKArlMRqvGc853jcAjkgg1XSbZenvKoEI-KuDZds2QEgYxxrdoQDTjYG%2Bk3iODHQAAclp%2BwjW28gpZAuUTSSmnaYVanXsOd4CCZJ5mRZCYJc6DWNvZhE6YFLlwORljuZ5i0%2BbhfmHYF4TBTxWL8YJwlRWJ2bmnFN2of9WVKQpW0QPD6GpS8O2OEMonAMUNwBH9AyTATgLFUsqwCJ4tDvu6OxgC2CAWOgNCWHV3WNYgzWXK1CGZAyjwAEIrK1d3jL1-W-ENaJAvOoLgnESMBWBTgggiuO3CLUuplinTdGzjaaik2rTgwEgcHiGuwnNJ1GdA3ifugM7-t0YrFG%2BAGm%2BgCDsHrXa-TNSs2vBcwe8hsNyQrKMsJLlvrcBpLE%2BiPaEAnUvHYZi1QLFsqXdOAEthtbu1awuwOwB6YFRbsEPY5-uka9bl3p93kK0VkO5rX-1QIDoWg5FokxVJuhh%2BxkfqqPJzj4ElfjHtKBaU9Stpwt95QOd2cM1dVk2dPenV0RKcTa572N3RX0t%2BifuK-9Azd8DYURce4MD-F1nOufsyT5l78hBHSWRxlWEdp4XCmDJ4HcIJQwPlAR4B9HCBwRDAYsNEN4%2B3AgbI2uovhUHVpGFWfwd4dGshzKQ8cO6wQdrA60BZ7QOSdKgy27pPQ0IkAANgACzDzRBjLsUYyFdngdGEOKEI4ELgWoShPVqEISEZwr%2BY8coW2gauPh4EBFYmWPOAkSUqBgk5BIm%2B3Ee4gL7tFNuKBJIwL-gojCmcYYqIGGo6AiDkHmXoY4dBOo4jAJJJmVwXAuBTnwdouARDOAkI7Arbxbhvr8KkSmWhZZRHjEYV0ZhfpZGpSSeEPxASND6MBI4iIMjf7yLRtlIMIAghAA)

Changeset included