### PR TITLE
Make use of discriminated unions if oneOf discriminator is defined

### DIFF
--- a/lib/src/openApiToZod.test.ts
+++ b/lib/src/openApiToZod.test.ts
@@ -27,30 +27,29 @@ test("getSchemaAsZodString", () => {
         '"z.object({ str: z.string() }).partial()"'
     );
 
-     expect(getSchemaAsZodString({ type: "object", properties: { str: { type: "string" } } })).toMatchInlineSnapshot(
+    expect(getSchemaAsZodString({ type: "object", properties: { str: { type: "string" } } })).toMatchInlineSnapshot(
         '"z.object({ str: z.string() }).partial()"'
     );
 
-    expect(
-        getSchemaAsZodString({ type: "object", properties: {  nb: { type: "integer" } } })
-    ).toMatchInlineSnapshot('"z.object({ nb: z.number().int() }).partial()"');
+    expect(getSchemaAsZodString({ type: "object", properties: { nb: { type: "integer" } } })).toMatchInlineSnapshot(
+        '"z.object({ nb: z.number().int() }).partial()"'
+    );
 
     expect(
-        getSchemaAsZodString({ type: "object", properties: {  pa: { type: "number", minimum: 0 } } })
+        getSchemaAsZodString({ type: "object", properties: { pa: { type: "number", minimum: 0 } } })
     ).toMatchInlineSnapshot('"z.object({ pa: z.number().gte(0) }).partial()"');
 
     expect(
-        getSchemaAsZodString({ type: "object", properties: {  pa: { type: "number", minimum: 0, maximum: 100 } } })
+        getSchemaAsZodString({ type: "object", properties: { pa: { type: "number", minimum: 0, maximum: 100 } } })
     ).toMatchInlineSnapshot(`"z.object({ pa: z.number().gte(0).lte(100) }).partial()"`);
 
     expect(
-        getSchemaAsZodString({ type: "object", properties: {  ml: { type: "string", minLength: 0 } } })
+        getSchemaAsZodString({ type: "object", properties: { ml: { type: "string", minLength: 0 } } })
     ).toMatchInlineSnapshot(`"z.object({ ml: z.string().min(0) }).partial()"`);
 
     expect(
-        getSchemaAsZodString({ type: "object", properties: {  dt: { type: "string", format: "date-time" } } })
+        getSchemaAsZodString({ type: "object", properties: { dt: { type: "string", format: "date-time" } } })
     ).toMatchInlineSnapshot(`"z.object({ dt: z.string().datetime() }).partial()"`);
-
 
     expect(
         getSchemaAsZodString({
@@ -130,6 +129,7 @@ test("getSchemaAsZodString", () => {
         '"z.union([z.literal(1), z.literal(2), z.literal(3), z.literal(null)])"'
     );
     expect(getSchemaAsZodString({ type: "number", enum: [1] })).toMatchInlineSnapshot('"z.literal(1)"');
+    expect(getSchemaAsZodString({ type: "string", enum: ["aString"] })).toMatchInlineSnapshot('"z.literal("aString")"');
 });
 
 test("getSchemaWithChainableAsZodString", () => {

--- a/lib/src/openApiToZod.test.ts
+++ b/lib/src/openApiToZod.test.ts
@@ -105,6 +105,45 @@ test("getSchemaAsZodString", () => {
     expect(
         getSchemaAsZodString({
             type: "object",
+            oneOf: [
+                {
+                    type: "object",
+                    required: ["type", "a"],
+                    properties: {
+                        type: {
+                            type: "string",
+                            enum: ["a"],
+                        },
+                        a: {
+                            type: "string",
+                        },
+                    },
+                },
+                {
+                    type: "object",
+                    required: ["type", "b"],
+                    properties: {
+                        type: {
+                            type: "string",
+                            enum: ["b"],
+                        },
+                        b: {
+                            type: "string",
+                        },
+                    },
+                },
+            ],
+            discriminator: { propertyName: "type" },
+        })
+    ).toMatchInlineSnapshot(`
+      "
+                      z.discriminatedUnion("type", [z.object({ type: z.literal("a"), a: z.string() }), z.object({ type: z.literal("b"), b: z.string() })]);
+                  "
+    `);
+
+    expect(
+        getSchemaAsZodString({
+            type: "object",
             properties: {
                 unionOrArrayOfUnion: { anyOf: [{ type: "string" }, { type: "number" }] },
             },

--- a/lib/src/openApiToZod.ts
+++ b/lib/src/openApiToZod.ts
@@ -85,6 +85,16 @@ export function getZodSchema({ schema, ctx, meta: inheritedMeta, options }: Conv
             return code.assign(type.toString());
         }
 
+        if (schema.discriminator) {
+            const propertyName = schema.discriminator.propertyName;
+
+            return code.assign(`
+                z.discriminatedUnion("${propertyName}", [${schema.oneOf
+                .map((prop) => getZodSchema({ schema: prop, ctx, meta, options }))
+                .join(", ")}]);
+            `);
+        }
+
         return code.assign(
             `z.union([${schema.oneOf.map((prop) => getZodSchema({ schema: prop, ctx, meta, options })).join(", ")}])`
         );

--- a/lib/src/openApiToZod.ts
+++ b/lib/src/openApiToZod.ts
@@ -122,6 +122,12 @@ export function getZodSchema({ schema, ctx, meta: inheritedMeta, options }: Conv
     if (schemaType && isPrimitiveType(schemaType)) {
         if (schema.enum) {
             if (schemaType === "string") {
+                if (schema.enum.length === 1) {
+                    const value = schema.enum[0];
+                    const valueString = value === null ? "null" : `"${value}"`;
+                    return code.assign(`z.literal(${valueString})`);
+                }
+
                 // eslint-disable-next-line sonarjs/no-nested-template-literals
                 return code.assign(`z.enum([${schema.enum.map((value) => `"${value}"`).join(", ")}])`);
             }


### PR DESCRIPTION
This PR ensures that we make use of Zod's discriminated unions if an oneOf discriminator is defined. It also ensures that we treat single value string enums as literals.

More details:
* [Inheritance and Polymorphism](https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/#:~:text=or%20complexObject.-,Discriminator,-To%20help%20API)
* [Discriminated unions](https://github.com/colinhacks/zod#discriminated-unions)