### PR TITLE
fix: correctly transform hyphenated path parameters

### DIFF
--- a/.changeset/perfect-mirrors-bake.md
+++ b/.changeset/perfect-mirrors-bake.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": patch
+---
+
+Handle hyphenated path parameters on endpoint definition

--- a/lib/tests/hyphenated-parameters.test.ts
+++ b/lib/tests/hyphenated-parameters.test.ts
@@ -1,0 +1,53 @@
+import type { OpenAPIObject } from "openapi3-ts";
+import { expect, test } from "vitest";
+import { generateZodClientFromOpenAPI } from "../src";
+
+// https://github.com/astahmer/openapi-zod-client/issues/78
+test("common-parameters", async () => {
+    const openApiDoc: OpenAPIObject = {
+        openapi: "3.0.3",
+        info: { title: "Swagger Petstore - OpenAPI 3.0", version: "1.0.11" },
+        paths: {
+            "/pet/{pet-id}/uploadImage": {
+                post: {
+                    parameters: [{ name: "pet-id", in: "path", required: true, schema: { type: "string" } }],
+                    responses: {
+                        "200": {
+                            description: "Successful operation",
+                            content: { "application/json": { schema: { type: "boolean" } } },
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    const output = await generateZodClientFromOpenAPI({ disableWriteToFile: true, openApiDoc });
+    expect(output).toMatchInlineSnapshot(`
+      "import { makeApi, Zodios, type ZodiosOptions } from "@zodios/core";
+      import { z } from "zod";
+
+      const endpoints = makeApi([
+        {
+          method: "post",
+          path: "/pet/:petId/uploadImage",
+          requestFormat: "json",
+          parameters: [
+            {
+              name: "petId",
+              type: "Path",
+              schema: z.string(),
+            },
+          ],
+          response: z.boolean(),
+        },
+      ]);
+
+      export const api = new Zodios(endpoints);
+
+      export function createApiClient(baseUrl: string, options?: ZodiosOptions) {
+        return new Zodios(baseUrl, endpoints, options);
+      }
+      "
+    `);
+});


### PR DESCRIPTION
When hyphenated path parameters are encountered, they are ignored in the generation step and kept as is eg. `param-Id`. When using the generated API, @zodios/code does not match these hyphenated parameters, but instead expect a camelCase parameter. 

This PR fixes this issue. 

@astahmer please let me know if this is rather something that should be addressed in the @zodios/code repo.