### PR TITLE
Fix TS generation of [any|one|all]Of when used with refs

### DIFF
--- a/.changeset/wise-peas-lay.md
+++ b/.changeset/wise-peas-lay.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": patch
+---
+
+Fix TS generation of [any|one|all]Of when used with refs

--- a/lib/src/openApiToTypescript.ts
+++ b/lib/src/openApiToTypescript.ts
@@ -45,7 +45,7 @@ TsConversionArgs): ts.Node | TypeDefinitionObject | string => {
             let result = ctx.nodeByRef[schema.$ref];
             const schemaName = ctx.resolver.resolveRef(schema.$ref)?.normalized;
             if (ctx.visitedsRefs[schema.$ref]) {
-                return schemaName;
+                return t.reference(schemaName);
             }
 
             if (!result) {
@@ -58,7 +58,7 @@ TsConversionArgs): ts.Node | TypeDefinitionObject | string => {
                 result = getTypescriptFromOpenApi({ schema: actualSchema, meta, ctx }) as ts.Node;
             }
 
-            return schemaName;
+            return t.reference(schemaName);
         }
 
         if (Array.isArray(schema.type)) {


### PR DESCRIPTION
`user: { oneOf: [{ $ref: "#/components/schemas/User" }, { $ref: "#/components/schemas/Member" }] },` outputs `user: "User" | "Member" ` instead of `user: User | Member`.

The issue comes from the fact that `getTypescriptFromOpenApi` resolves a`$ref` name as a string literal, which is then passed to `t.union` (ie: `t.union(["User", "Member"])`).

It seems that the fix is to just resolve `$ref` as `t.reference(nameString)` instead of just `nameString`.

Added a test to repro the issue, here is how it failed before the fix:
![Screenshot 2023-06-01 at 18 58 18](https://github.com/astahmer/openapi-zod-client/assets/277455/c8a4a648-30da-4faf-a953-24addfdd2a80)
