### PR TITLE
allow timezones in date-time strings, per openapi

### DIFF
--- a/lib/src/generateZodClientFromOpenAPI.test.ts
+++ b/lib/src/generateZodClientFromOpenAPI.test.ts
@@ -472,7 +472,7 @@ test("getZodClientTemplateContext", async () => {
           "schemas": {
               "ApiResponse": "z.object({ code: z.number().int(), type: z.string(), message: z.string() }).partial()",
               "Category": "z.object({ id: z.number().int(), name: z.string() }).partial()",
-              "Order": "z.object({ id: z.number().int(), petId: z.number().int(), quantity: z.number().int(), shipDate: z.string().datetime(), status: z.enum(["placed", "approved", "delivered"]), complete: z.boolean() }).partial()",
+              "Order": "z.object({ id: z.number().int(), petId: z.number().int(), quantity: z.number().int(), shipDate: z.string().datetime({ offset: true }), status: z.enum(["placed", "approved", "delivered"]), complete: z.boolean() }).partial()",
               "Pet": "z.object({ id: z.number().int().optional(), name: z.string(), category: Category.optional(), photoUrls: z.array(z.string()), tags: z.array(Tag).optional(), status: z.enum(["available", "pending", "sold"]).optional() })",
               "Tag": "z.object({ id: z.number().int(), name: z.string() }).partial()",
               "User": "z.object({ id: z.number().int(), username: z.string(), firstName: z.string(), lastName: z.string(), email: z.string(), password: z.string(), phone: z.string(), userStatus: z.number().int() }).partial()",
@@ -507,7 +507,7 @@ describe("generateZodClientFromOpenAPI", () => {
               id: z.number().int(),
               petId: z.number().int(),
               quantity: z.number().int(),
-              shipDate: z.string().datetime(),
+              shipDate: z.string().datetime({ offset: true }),
               status: z.enum(["placed", "approved", "delivered"]),
               complete: z.boolean(),
             })
@@ -989,7 +989,7 @@ describe("generateZodClientFromOpenAPI", () => {
               id: z.number().int(),
               petId: z.number().int(),
               quantity: z.number().int(),
-              shipDate: z.string().datetime(),
+              shipDate: z.string().datetime({ offset: true }),
               status: z.enum(["placed", "approved", "delivered"]),
               complete: z.boolean(),
             })
@@ -1495,7 +1495,7 @@ describe("generateZodClientFromOpenAPI", () => {
             id: z.number().int(),
             petId: z.number().int(),
             quantity: z.number().int(),
-            shipDate: z.string().datetime(),
+            shipDate: z.string().datetime({ offset: true }),
             status: z.enum(["placed", "approved", "delivered"]),
             complete: z.boolean(),
           })
@@ -1998,7 +1998,7 @@ describe("generateZodClientFromOpenAPI", () => {
               id: z.number().int(),
               petId: z.number().int(),
               quantity: z.number().int(),
-              shipDate: z.string().datetime(),
+              shipDate: z.string().datetime({ offset: true }),
               status: z.enum(["placed", "approved", "delivered"]),
               complete: z.boolean(),
             })
@@ -2482,7 +2482,7 @@ describe("generateZodClientFromOpenAPI", () => {
             id: z.number().int(),
             petId: z.number().int(),
             quantity: z.number().int(),
-            shipDate: z.string().datetime(),
+            shipDate: z.string().datetime({ offset: true }),
             status: z.enum(["placed", "approved", "delivered"]),
             complete: z.boolean(),
           })

--- a/lib/src/getZodiosEndpointDefinitionList.test.ts
+++ b/lib/src/getZodiosEndpointDefinitionList.test.ts
@@ -150,7 +150,7 @@ test("getZodiosEndpointDefinitionList /store/order", () => {
           },
           "schemaByName": {},
           "zodSchemaByName": {
-              "Order": "z.object({ id: z.number().int(), petId: z.number().int(), quantity: z.number().int(), shipDate: z.string().datetime(), status: z.enum(["placed", "approved", "delivered"]), complete: z.boolean() }).partial()",
+              "Order": "z.object({ id: z.number().int(), petId: z.number().int(), quantity: z.number().int(), shipDate: z.string().datetime({ offset: true }), status: z.enum(["placed", "approved", "delivered"]), complete: z.boolean() }).partial()",
           },
       }
     `);
@@ -1143,7 +1143,7 @@ test("petstore.yaml", async () => {
           "zodSchemaByName": {
               "ApiResponse": "z.object({ code: z.number().int(), type: z.string(), message: z.string() }).partial()",
               "Category": "z.object({ id: z.number().int(), name: z.string() }).partial()",
-              "Order": "z.object({ id: z.number().int(), petId: z.number().int(), quantity: z.number().int(), shipDate: z.string().datetime(), status: z.enum(["placed", "approved", "delivered"]), complete: z.boolean() }).partial()",
+              "Order": "z.object({ id: z.number().int(), petId: z.number().int(), quantity: z.number().int(), shipDate: z.string().datetime({ offset: true }), status: z.enum(["placed", "approved", "delivered"]), complete: z.boolean() }).partial()",
               "Pet": "z.object({ id: z.number().int().optional(), name: z.string(), category: Category.optional(), photoUrls: z.array(z.string()), tags: z.array(Tag).optional(), status: z.enum(["available", "pending", "sold"]).optional() })",
               "Tag": "z.object({ id: z.number().int(), name: z.string() }).partial()",
               "User": "z.object({ id: z.number().int(), username: z.string(), firstName: z.string(), lastName: z.string(), email: z.string(), password: z.string(), phone: z.string(), userStatus: z.number().int() }).partial()",

--- a/lib/src/openApiToZod.test.ts
+++ b/lib/src/openApiToZod.test.ts
@@ -49,7 +49,7 @@ test("getSchemaAsZodString", () => {
 
     expect(
         getSchemaAsZodString({ type: "object", properties: { dt: { type: "string", format: "date-time" } } })
-    ).toMatchInlineSnapshot(`"z.object({ dt: z.string().datetime() }).partial()"`);
+    ).toMatchInlineSnapshot('"z.object({ dt: z.string().datetime({ offset: true }) }).partial()"');
 
     expect(
         getSchemaAsZodString({

--- a/lib/src/openApiToZod.ts
+++ b/lib/src/openApiToZod.ts
@@ -348,7 +348,7 @@ const getZodChainableStringValidations = (schema: SchemaObject) => {
             .with("hostname", () => "url()")
             .with("uri", () => "url()")
             .with("uuid", () => "uuid()")
-            .with("date-time", () => "datetime()")
+            .with("date-time", () => "datetime({ offset: true })")
             .otherwise(() => "");
 
         if (chain) {


### PR DESCRIPTION
the openapi spec says that date-time strings conform to [RFC 3339, section 5.6](https://tools.ietf.org/html/rfc3339#section-5.6), which allows timezone offsets.

however by default zod will reject date-times with timezones.

```ts
const date = "2022-09-02T07:50:45+02:00"

z.string().datetime().parse(date) // fails 
```

the fix is to set `offset` option to true:

```ts
z.string().datetime({ offset: true }).parse(date) // passes
```

this change adds that option. i think you'd always want this enabled, given the openapi spec, so i haven't added it as a config option