### PR TITLE
feat: add endpointDefinitionRefiner to TemplateContext options

### DIFF
--- a/.changeset/thin-hats-sneeze.md
+++ b/.changeset/thin-hats-sneeze.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": minor
+---
+
+feat: add endpointDefinitionRefiner to TemplateContext options

--- a/lib/src/getZodiosEndpointDefinitionList.ts
+++ b/lib/src/getZodiosEndpointDefinitionList.ts
@@ -151,7 +151,7 @@ export const getZodiosEndpointDefinitionList = (doc: OpenAPIObject, options?: Te
                 ...getParametersMap(operation.parameters ?? []),
             }).map(([_id, param]) => param);
             const operationName = getOperationAlias(path, method, operation);
-            const endpointDefinition: EndpointDefinitionWithRefs = {
+            let endpointDefinition: EndpointDefinitionWithRefs = {
                 method: method as EndpointDefinitionWithRefs["method"],
                 path: replaceHyphenatedPath(path),
                 ...(options?.withAlias && { alias: operationName }),
@@ -161,6 +161,12 @@ export const getZodiosEndpointDefinitionList = (doc: OpenAPIObject, options?: Te
                 errors: [],
                 response: "",
             };
+
+            if (options?.endpointDefinitionRefiner) {
+                // Refine the endpoint definition, in case consumer wants to add some specific fields
+                // to be rendered in the Handlebars template.
+                endpointDefinition = options.endpointDefinitionRefiner(endpointDefinition, operation);
+            }
 
             if (operation.requestBody) {
                 const requestBody = (
@@ -225,7 +231,6 @@ export const getZodiosEndpointDefinitionList = (doc: OpenAPIObject, options?: Te
                                 `No content with media type for param ${paramItem.name}: ${matchingMediaType}`
                             );
                         }
-
 
                         // this fallback is needed to autofix openapi docs that put the $ref in the wrong place
                         // (it should be in the mediaTypeObject.schema, not in the mediaTypeObject itself)

--- a/lib/src/template-context.ts
+++ b/lib/src/template-context.ts
@@ -339,4 +339,12 @@ export type TemplateContextOptions = {
      * @see https://github.com/astahmer/openapi-zod-client/pull/143
      */
     withDescription?: boolean;
+    /**
+     * A function to refine the default endpoint definition. Mostly useful for adding fields from OperationObject
+     * that aren't defined yet in the default definition.
+     */
+    endpointDefinitionRefiner?: (
+        defaultDefinition: EndpointDefinitionWithRefs,
+        operation: OperationObject
+    ) => EndpointDefinitionWithRefs;
 };

--- a/lib/tests/refine-default-endpoint-callback.test.ts
+++ b/lib/tests/refine-default-endpoint-callback.test.ts
@@ -1,0 +1,134 @@
+import { getZodiosEndpointDefinitionList } from "../src";
+import { expect, test } from "vitest";
+
+test("refine-default-endpoint-callback", () => {
+    // Without the refiner function passed.
+    expect(
+        getZodiosEndpointDefinitionList({
+            openapi: "3.0.3",
+            info: { version: "1", title: "Example API" },
+            paths: {
+                "/basic-schema": {
+                    get: {
+                        operationId: "getBasicSchema",
+                        responses: {
+                            "200": {
+                                content: { "application/json": { schema: { $ref: "#/components/schemas/Basic" } } },
+                            },
+                        },
+                    },
+                },
+            },
+            components: {
+                schemas: {
+                    Basic: { type: "string" },
+                },
+            },
+        })
+    ).toMatchInlineSnapshot(`
+      {
+          "deepDependencyGraph": {},
+          "endpoints": [
+              {
+                  "description": undefined,
+                  "errors": [],
+                  "method": "get",
+                  "parameters": [],
+                  "path": "/basic-schema",
+                  "requestFormat": "json",
+                  "response": "z.string()",
+              },
+          ],
+          "issues": {
+              "ignoredFallbackResponse": [],
+              "ignoredGenericError": [],
+          },
+          "refsDependencyGraph": {},
+          "resolver": {
+              "getSchemaByRef": [Function],
+              "resolveRef": [Function],
+              "resolveSchemaName": [Function],
+          },
+          "schemaByName": {},
+          "zodSchemaByName": {
+              "Basic": "z.string()",
+          },
+      }
+    `);
+
+    // With the refiner function passed.
+    expect(
+        getZodiosEndpointDefinitionList(
+            {
+                openapi: "3.0.3",
+                info: { version: "1", title: "Example API" },
+                paths: {
+                    "/basic-schema": {
+                        get: {
+                            operationId: "getBasicSchema",
+                            responses: {
+                                "200": {
+                                    content: { "application/json": { schema: { $ref: "#/components/schemas/Basic" } } },
+                                },
+                            },
+                            security: [
+                                {
+                                    petstore_auth: ["read:schema"],
+                                },
+                            ],
+                        },
+                    },
+                },
+                components: {
+                    schemas: {
+                        Basic: { type: "string" },
+                    },
+                },
+            },
+            {
+                endpointDefinitionRefiner: (defaultDefinition, operation) => ({
+                    ...defaultDefinition,
+                    operationId: operation.operationId,
+                    security: operation.security,
+                }),
+            }
+        )
+    ).toMatchInlineSnapshot(`
+      {
+          "deepDependencyGraph": {},
+          "endpoints": [
+              {
+                  "description": undefined,
+                  "errors": [],
+                  "method": "get",
+                  "operationId": "getBasicSchema",
+                  "parameters": [],
+                  "path": "/basic-schema",
+                  "requestFormat": "json",
+                  "response": "z.string()",
+                  "security": [
+                      {
+                          "petstore_auth": [
+                              "read:schema",
+                          ],
+                      },
+                  ],
+              },
+          ],
+          "issues": {
+              "ignoredFallbackResponse": [],
+              "ignoredGenericError": [],
+          },
+          "refsDependencyGraph": {},
+          "resolver": {
+              "getSchemaByRef": [Function],
+              "resolveRef": [Function],
+              "resolveSchemaName": [Function],
+          },
+          "schemaByName": {},
+          "zodSchemaByName": {
+              "Basic": "z.string()",
+          },
+      }
+    `);
+});


### PR DESCRIPTION
This PR closes https://github.com/astahmer/openapi-zod-client/issues/173. Initially I wanted to pass it as another field of the parameter for `generateZodClientFromOpenAPI`, but seems like `TemplateContextOptions` is the better way. Let me know if it perhaps is better to move it to another part.

Bumping the minor version in the changeset since I consider it a new feature (?) CMIIW on this part.

The test part is using the example from the issue, that is, using the `security` and `operationId`, which doesn't exist in the default definition. After we add that refiner function, these 2 fields exist in the resulting endpoints definition.

```
➜ /workspaces/openapi-zod-client (gh-173-refiner-callback-fn) $ pnpm test

...

Test Files  54 passed (54)
     Tests  95 passed (95)
  Start at  14:40:44
  Duration  185.32s (transform 1.93s, setup 2ms, collect 90.43s, tests 35.53s)
````