### PR TITLE
fix: Fixed an error when requestBody was of type "object"

### DIFF
--- a/lib/src/getZodiosEndpointDefinitionList.ts
+++ b/lib/src/getZodiosEndpointDefinitionList.ts
@@ -106,7 +106,7 @@ export const getZodiosEndpointDefinitionList = (doc: OpenAPIObject, options?: Te
 
             ctx.zodSchemaByName[formatedName] = result;
             ctx.schemaByName[result] = formatedName;
-            return formatedName;
+            return result;
         }
 
         // result is a reference to another schema

--- a/lib/tests/request-body-object.test.ts
+++ b/lib/tests/request-body-object.test.ts
@@ -1,0 +1,89 @@
+import type { OpenAPIObject } from "openapi3-ts";
+import { expect, test } from "vitest";
+import { generateZodClientFromOpenAPI } from "../src";
+
+
+test("request-body-object", async () => {
+    const openApiDoc: OpenAPIObject = {
+        openapi: "3.0.3",
+        info: {
+            title: "Pets",
+            version: "1.0.0",
+        },
+        paths: {
+            "/pets": {
+                post: {
+                    summary: "Post pets.",
+                    operationId: "PostPets",
+                    requestBody: {
+                        content: {
+                            "application/json": {
+                                schema: {
+                                    type: "object",
+                                    properties: {
+                                        data: {
+                                            $ref: "#/components/schemas/PostPetsRequest",
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                    responses: {},
+                },
+            },
+        },
+        components: {
+            schemas: {
+                PostPetsRequest: {
+                    type: "object",
+                    properties: {
+                        id: {
+                            type: "string",
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    const output = await generateZodClientFromOpenAPI({ disableWriteToFile: true, openApiDoc });
+    expect(output).toMatchInlineSnapshot(`
+      "import { makeApi, Zodios, type ZodiosOptions } from "@zodios/core";
+      import { z } from "zod";
+
+      const PostPetsRequest = z.object({ id: z.string() }).partial().passthrough();
+      const PostPets_Body = z
+        .object({ data: PostPetsRequest })
+        .partial()
+        .passthrough();
+
+      export const schemas = {
+        PostPetsRequest,
+        PostPets_Body,
+      };
+
+      const endpoints = makeApi([
+        {
+          method: "post",
+          path: "/pets",
+          requestFormat: "json",
+          parameters: [
+            {
+              name: "body",
+              type: "Body",
+              schema: z.object({ data: PostPetsRequest }).partial().passthrough(),
+            },
+          ],
+          response: z.void(),
+        },
+      ]);
+
+      export const api = new Zodios(endpoints);
+
+      export function createApiClient(baseUrl: string, options?: ZodiosOptions) {
+        return new Zodios(baseUrl, endpoints, options);
+      }
+      "
+    `);
+});


### PR DESCRIPTION
Fixed an error when requestBody was of type "object"
When the requestBody type is Object, an error is reported

``` json
{
    "openapi": "3.0.3",
    "info": {
        "title": "Pets",
        "version": "1.0.0"
    },
    "paths": {
        "/pets": {
            "post": {
                "summary": "Post pets.",
                "operationId": "PostPets",
                "requestBody": {
                    "content": {
                        "application/json": {
                            "schema": {
                                "type": "object",
                                "properties": {
                                    "data": {
                                        "$ref": "#/components/schemas/PostPetsRequest"
                                    }
                                }
                            }
                        }
                    }
                },
                "responses": {}
            }
        }
    },
    "components": {
        "schemas": {
            "PostPetsRequest": {
                "type": "object",
                "properties": {
                    "id": {
                        "type": "string"
                    }
                }
            }
        }
    }
}
```

```
depsGraphs.deepDependencyGraph[result.resolver.resolveSchemaName(schemaName).ref]?.forEach(
                                                                                      ^

TypeError: Cannot read properties of undefined (reading 'ref')
    at /Users/liufengmao/Desktop/vjshi/zod-test/packages/openapi-zod-client-vjs/dist/cli.js:1228:87
    at Array.forEach (<anonymous>)
    at /Users/liufengmao/Desktop/vjshi/zod-test/packages/openapi-zod-client-vjs/dist/cli.js:1223:27
    at Array.forEach (<anonymous>)
    at getZodClientTemplateContext (/Users/liufengmao/Desktop/vjshi/zod-test/packages/openapi-zod-client-vjs/dist/cli.js:1188:20)
    at generateZodClientFromOpenAPI (/Users/liufengmao/Desktop/vjshi/zod-test/packages/openapi-zod-client-vjs/dist/cli.js:1298:16)
    at CAC.<anonymous> (/Users/liufengmao/Desktop/vjshi/zod-test/packages/openapi-zod-client-vjs/dist/cli.js:1422:9)

Node.js v20.3.1
```
