### PR TITLE
Add escaping colon in paths

### DIFF
--- a/.changeset/escape_colon_in_path.md
+++ b/.changeset/escape_colon_in_path.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": minor
+---
+
+escape colon in OpenAPI path

--- a/lib/src/getZodiosEndpointDefinitionList.test.ts
+++ b/lib/src/getZodiosEndpointDefinitionList.test.ts
@@ -646,6 +646,99 @@ test("getZodiosEndpointDefinitionList /pet/findXXX", () => {
     `);
 });
 
+test("getZodiosEndpointDefinitionList /pet/{petId}:action-name", () => {
+    expect(
+        getZodiosEndpointDefinitionList({
+            ...baseDoc,
+            components: { schemas: { Pet: schemas.Pet, Category: schemas.Category, Tag: schemas.Tag } },
+            paths: {
+                "/pet/{petId}:action-name": {
+                    "get": {
+                        "tags": [
+                            "pet"
+                        ],
+                        "summary": "Runs action for a pet",
+                        "description": "Runs action for a pet",
+                        "operationId": "petByIdAction",
+                        "parameters": [
+                            {
+                                "name": "petId",
+                                "in": "path",
+                                "description": "ID of pet to return",
+                                "required": true,
+                                "schema": {
+                                    "type": "integer",
+                                    "format": "int64"
+                                }
+                            }
+                        ],
+                        "responses": {
+                            "200": {
+                                "description": "successful action call",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "$ref": "#/components/schemas/Pet"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "security": []
+                    },
+                }
+            },
+        })
+    ).toMatchInlineSnapshot(`
+      {
+          "deepDependencyGraph": {
+              "#/components/schemas/Pet": Set {
+                  "#/components/schemas/Category",
+                  "#/components/schemas/Tag",
+              },
+          },
+          "endpoints": [
+              {
+                  "description": "Runs action for a pet",
+                  "errors": [],
+                  "method": "get",
+                  "parameters": [
+                      {
+                          "name": "petId",
+                          "schema": "z.number().int()",
+                          "type": "Path",
+                      },
+                  ],
+                  "path": "/pet/:petId:action-name",
+                  "requestFormat": "json",
+                  "response": "Pet",
+              },
+          ],
+          "issues": {
+              "ignoredFallbackResponse": [],
+              "ignoredGenericError": [],
+          },
+          "refsDependencyGraph": {
+              "#/components/schemas/Pet": Set {
+                  "#/components/schemas/Category",
+                  "#/components/schemas/Tag",
+              },
+          },
+          "resolver": {
+              "getSchemaByRef": [Function],
+              "resolveRef": [Function],
+              "resolveSchemaName": [Function],
+          },
+          "schemaByName": {},
+          "zodSchemaByName": {
+              "Category": "z.object({ id: z.number().int(), name: z.string() }).partial().passthrough()",
+              "Pet": "z.object({ id: z.number().int().optional(), name: z.string(), category: Category.optional(), photoUrls: z.array(z.string()), tags: z.array(Tag).optional(), status: z.enum(["available", "pending", "sold"]).optional() }).passthrough()",
+              "Tag": "z.object({ id: z.number().int(), name: z.string() }).partial().passthrough()",
+          },
+      }
+    `);
+});
+
 test("petstore.yaml", async () => {
     const openApiDoc = (await SwaggerParser.parse("./tests/petstore.yaml")) as OpenAPIObject;
     const result = getZodiosEndpointDefinitionList(openApiDoc);

--- a/lib/src/getZodiosEndpointDefinitionList.test.ts
+++ b/lib/src/getZodiosEndpointDefinitionList.test.ts
@@ -709,7 +709,7 @@ test("getZodiosEndpointDefinitionList /pet/{petId}:action-name", () => {
                           "type": "Path",
                       },
                   ],
-                  "path": "/pet/:petId:action-name",
+                  "path": "/pet/:petId%3Aaction-name",
                   "requestFormat": "json",
                   "response": "Pet",
               },

--- a/lib/src/utils.ts
+++ b/lib/src/utils.ts
@@ -42,6 +42,7 @@ export const pathParamToVariableName = (name: string) => {
 
 const matcherRegex = /{(\b\w+(?:-\w+)*\b)}/g;
 export const replaceHyphenatedPath = (path: string) => {
+    path = path.replace(":", encodeURIComponent(":"))
     const matches = path.match(matcherRegex);
     if (matches === null) {
         return path.replaceAll(matcherRegex, ":$1");


### PR DESCRIPTION
This library changes OpenAPI path parameters syntax to match one used by zodios.
`/pet/{petId}:action-name` -> `/pet/:petId:action-name`

However this may cause the wrong parameter detection in zodios.
In given case zodios finds one parameter in path: `petId:action-name` which is not true.

Given fix along with zodios changes resolves this issue.
This PR requires https://github.com/ecyrbe/zodios/pull/486