### PR TITLE
fix min/max handling for numerical enums

### DIFF
--- a/lib/src/openApiToZod.ts
+++ b/lib/src/openApiToZod.ts
@@ -358,7 +358,12 @@ const getZodChainableStringValidations = (schema: SchemaObject) => {
 const getZodChainableNumberValidations = (schema: SchemaObject) => {
     const validations: string[] = [];
 
-    if (schema.type === "integer" && !schema.enum) {
+    // none of the chains are valid for enums
+    if (schema.enum) {
+        return "";
+    }
+
+    if (schema.type === "integer") {
         validations.push("int()");
     }
 

--- a/lib/tests/enum-min-max.test.ts
+++ b/lib/tests/enum-min-max.test.ts
@@ -20,7 +20,8 @@ test("enum-min-max", async () => {
                             schema: {
                                 type: "integer",
                                 enum: [1, -2, 3],
-                                min: 4,
+                                minimum: 4,
+                                maximum: 10,
                             },
                         },
                         {


### PR DESCRIPTION
small fix: i noticed that `gte()`/`lte()` etc chains still got added to numerical enums. this wasn't caught by tests because the test case incorrectly used `min`/`max` instead of `minimum`/`maximum`.

now the generation will skip all chains for numerical enums and the test case has been updated