### PR TITLE
fix: fix order of schemas when using option groupStrategy: tag-file

### DIFF
--- a/.changeset/fifty-vans-swim.md
+++ b/.changeset/fifty-vans-swim.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": patch
+---
+
+fix: fix order of schemas when using option groupStrategy: tag-file

--- a/lib/src/generateZodClientFromOpenAPI.test.ts
+++ b/lib/src/generateZodClientFromOpenAPI.test.ts
@@ -463,7 +463,7 @@ test("getZodClientTemplateContext", async () => {
     `);
 });
 
-describe("generateZodClientFromOpenAPI", () => {
+describe.only("generateZodClientFromOpenAPI", () => {
     test("without options", async () => {
         const prettyOutput = await generateZodClientFromOpenAPI({ openApiDoc, disableWriteToFile: true });
         expect(prettyOutput).toMatchInlineSnapshot(`
@@ -1955,8 +1955,8 @@ describe("generateZodClientFromOpenAPI", () => {
             return new Zodios(baseUrl, endpoints, options);
           }
           "
-        `)
-    })
+        `);
+    });
 
     test("withAlias as a custom function", async () => {
         const prettyOutput = await generateZodClientFromOpenAPI({
@@ -2970,7 +2970,7 @@ describe("generateZodClientFromOpenAPI", () => {
         `);
     });
 
-    test("without default values", async () => {
+    test("with tag-file option", async () => {
         const prettyOutput = await generateZodClientFromOpenAPI({
             openApiDoc,
             disableWriteToFile: true,
@@ -3460,6 +3460,499 @@ describe("generateZodClientFromOpenAPI", () => {
           }
           "
         `);
+    });
+
+    test.only("without options", async () => {
+        const prettyOutput = await generateZodClientFromOpenAPI({
+            openApiDoc,
+            disableWriteToFile: true,
+            options: { groupStrategy: "tag-file" },
+        });
+        expect(prettyOutput).toMatchInlineSnapshot(`
+        "import { makeApi, Zodios, type ZodiosOptions } from "@zodios/core";
+        import { z } from "zod";
+
+        const Category = z
+          .object({ id: z.number().int(), name: z.string() })
+          .partial()
+          .passthrough();
+        const Tag = z
+          .object({ id: z.number().int(), name: z.string() })
+          .partial()
+          .passthrough();
+        const Pet = z
+          .object({
+            id: z.number().int().optional(),
+            name: z.string(),
+            category: Category.optional(),
+            photoUrls: z.array(z.string()),
+            tags: z.array(Tag).optional(),
+            status: z.enum(["available", "pending", "sold"]).optional(),
+          })
+          .passthrough();
+        const ApiResponse = z
+          .object({ code: z.number().int(), type: z.string(), message: z.string() })
+          .partial()
+          .passthrough();
+        const Order = z
+          .object({
+            id: z.number().int(),
+            petId: z.number().int(),
+            quantity: z.number().int(),
+            shipDate: z.string().datetime({ offset: true }),
+            status: z.enum(["placed", "approved", "delivered"]),
+            complete: z.boolean(),
+          })
+          .partial()
+          .passthrough();
+        const User = z
+          .object({
+            id: z.number().int(),
+            username: z.string(),
+            firstName: z.string(),
+            lastName: z.string(),
+            email: z.string(),
+            password: z.string(),
+            phone: z.string(),
+            userStatus: z.number().int(),
+          })
+          .partial()
+          .passthrough();
+
+        export const schemas = {
+          Category,
+          Tag,
+          Pet,
+          ApiResponse,
+          Order,
+          User,
+        };
+
+        const endpoints = makeApi([
+          {
+            method: "put",
+            path: "/pet",
+            description: \`Update an existing pet by Id\`,
+            requestFormat: "json",
+            parameters: [
+              {
+                name: "body",
+                description: \`Update an existent pet in the store\`,
+                type: "Body",
+                schema: Pet,
+              },
+            ],
+            response: Pet,
+            errors: [
+              {
+                status: 400,
+                description: \`Invalid ID supplied\`,
+                schema: z.void(),
+              },
+              {
+                status: 404,
+                description: \`Pet not found\`,
+                schema: z.void(),
+              },
+              {
+                status: 405,
+                description: \`Validation exception\`,
+                schema: z.void(),
+              },
+            ],
+          },
+          {
+            method: "post",
+            path: "/pet",
+            description: \`Add a new pet to the store\`,
+            requestFormat: "json",
+            parameters: [
+              {
+                name: "body",
+                description: \`Create a new pet in the store\`,
+                type: "Body",
+                schema: Pet,
+              },
+            ],
+            response: Pet,
+            errors: [
+              {
+                status: 405,
+                description: \`Invalid input\`,
+                schema: z.void(),
+              },
+            ],
+          },
+          {
+            method: "get",
+            path: "/pet/:petId",
+            description: \`Returns a single pet\`,
+            requestFormat: "json",
+            parameters: [
+              {
+                name: "petId",
+                type: "Path",
+                schema: z.number().int(),
+              },
+            ],
+            response: Pet,
+            errors: [
+              {
+                status: 400,
+                description: \`Invalid ID supplied\`,
+                schema: z.void(),
+              },
+              {
+                status: 404,
+                description: \`Pet not found\`,
+                schema: z.void(),
+              },
+            ],
+          },
+          {
+            method: "post",
+            path: "/pet/:petId",
+            requestFormat: "json",
+            parameters: [
+              {
+                name: "petId",
+                type: "Path",
+                schema: z.number().int(),
+              },
+              {
+                name: "name",
+                type: "Query",
+                schema: z.string().optional(),
+              },
+              {
+                name: "status",
+                type: "Query",
+                schema: z.string().optional(),
+              },
+            ],
+            response: z.void(),
+            errors: [
+              {
+                status: 405,
+                description: \`Invalid input\`,
+                schema: z.void(),
+              },
+            ],
+          },
+          {
+            method: "delete",
+            path: "/pet/:petId",
+            description: \`delete a pet\`,
+            requestFormat: "json",
+            parameters: [
+              {
+                name: "api_key",
+                type: "Header",
+                schema: z.string().optional(),
+              },
+              {
+                name: "petId",
+                type: "Path",
+                schema: z.number().int(),
+              },
+            ],
+            response: z.void(),
+            errors: [
+              {
+                status: 400,
+                description: \`Invalid pet value\`,
+                schema: z.void(),
+              },
+            ],
+          },
+          {
+            method: "post",
+            path: "/pet/:petId/uploadImage",
+            requestFormat: "binary",
+            parameters: [
+              {
+                name: "body",
+                type: "Body",
+                schema: z.instanceof(File),
+              },
+              {
+                name: "petId",
+                type: "Path",
+                schema: z.number().int(),
+              },
+              {
+                name: "additionalMetadata",
+                type: "Query",
+                schema: z.string().optional(),
+              },
+            ],
+            response: ApiResponse,
+          },
+          {
+            method: "get",
+            path: "/pet/findByStatus",
+            description: \`Multiple status values can be provided with comma separated strings\`,
+            requestFormat: "json",
+            parameters: [
+              {
+                name: "status",
+                type: "Query",
+                schema: z
+                  .enum(["available", "pending", "sold"])
+                  .optional()
+                  .default("available"),
+              },
+            ],
+            response: z.array(Pet),
+            errors: [
+              {
+                status: 400,
+                description: \`Invalid status value\`,
+                schema: z.void(),
+              },
+            ],
+          },
+          {
+            method: "get",
+            path: "/pet/findByTags",
+            description: \`Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.\`,
+            requestFormat: "json",
+            parameters: [
+              {
+                name: "tags",
+                type: "Query",
+                schema: z.array(z.string()).optional(),
+              },
+            ],
+            response: z.array(Pet),
+            errors: [
+              {
+                status: 400,
+                description: \`Invalid tag value\`,
+                schema: z.void(),
+              },
+            ],
+          },
+          {
+            method: "get",
+            path: "/store/inventory",
+            description: \`Returns a map of status codes to quantities\`,
+            requestFormat: "json",
+            response: z.record(z.number()),
+          },
+          {
+            method: "post",
+            path: "/store/order",
+            description: \`Place a new order in the store\`,
+            requestFormat: "json",
+            parameters: [
+              {
+                name: "body",
+                type: "Body",
+                schema: Order,
+              },
+            ],
+            response: Order,
+            errors: [
+              {
+                status: 405,
+                description: \`Invalid input\`,
+                schema: z.void(),
+              },
+            ],
+          },
+          {
+            method: "get",
+            path: "/store/order/:orderId",
+            description: \`For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions.\`,
+            requestFormat: "json",
+            parameters: [
+              {
+                name: "orderId",
+                type: "Path",
+                schema: z.number().int(),
+              },
+            ],
+            response: Order,
+            errors: [
+              {
+                status: 400,
+                description: \`Invalid ID supplied\`,
+                schema: z.void(),
+              },
+              {
+                status: 404,
+                description: \`Order not found\`,
+                schema: z.void(),
+              },
+            ],
+          },
+          {
+            method: "delete",
+            path: "/store/order/:orderId",
+            description: \`For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors\`,
+            requestFormat: "json",
+            parameters: [
+              {
+                name: "orderId",
+                type: "Path",
+                schema: z.number().int(),
+              },
+            ],
+            response: z.void(),
+            errors: [
+              {
+                status: 400,
+                description: \`Invalid ID supplied\`,
+                schema: z.void(),
+              },
+              {
+                status: 404,
+                description: \`Order not found\`,
+                schema: z.void(),
+              },
+            ],
+          },
+          {
+            method: "post",
+            path: "/user",
+            description: \`This can only be done by the logged in user.\`,
+            requestFormat: "json",
+            parameters: [
+              {
+                name: "body",
+                description: \`Created user object\`,
+                type: "Body",
+                schema: User,
+              },
+            ],
+            response: z.void(),
+          },
+          {
+            method: "get",
+            path: "/user/:username",
+            requestFormat: "json",
+            parameters: [
+              {
+                name: "username",
+                type: "Path",
+                schema: z.string(),
+              },
+            ],
+            response: User,
+            errors: [
+              {
+                status: 400,
+                description: \`Invalid username supplied\`,
+                schema: z.void(),
+              },
+              {
+                status: 404,
+                description: \`User not found\`,
+                schema: z.void(),
+              },
+            ],
+          },
+          {
+            method: "put",
+            path: "/user/:username",
+            description: \`This can only be done by the logged in user.\`,
+            requestFormat: "json",
+            parameters: [
+              {
+                name: "body",
+                description: \`Update an existent user in the store\`,
+                type: "Body",
+                schema: User,
+              },
+              {
+                name: "username",
+                type: "Path",
+                schema: z.string(),
+              },
+            ],
+            response: z.void(),
+          },
+          {
+            method: "delete",
+            path: "/user/:username",
+            description: \`This can only be done by the logged in user.\`,
+            requestFormat: "json",
+            parameters: [
+              {
+                name: "username",
+                type: "Path",
+                schema: z.string(),
+              },
+            ],
+            response: z.void(),
+            errors: [
+              {
+                status: 400,
+                description: \`Invalid username supplied\`,
+                schema: z.void(),
+              },
+              {
+                status: 404,
+                description: \`User not found\`,
+                schema: z.void(),
+              },
+            ],
+          },
+          {
+            method: "post",
+            path: "/user/createWithList",
+            description: \`Creates list of users with given input array\`,
+            requestFormat: "json",
+            parameters: [
+              {
+                name: "body",
+                type: "Body",
+                schema: z.array(User),
+              },
+            ],
+            response: User,
+          },
+          {
+            method: "get",
+            path: "/user/login",
+            requestFormat: "json",
+            parameters: [
+              {
+                name: "username",
+                type: "Query",
+                schema: z.string().optional(),
+              },
+              {
+                name: "password",
+                type: "Query",
+                schema: z.string().optional(),
+              },
+            ],
+            response: z.string(),
+            errors: [
+              {
+                status: 400,
+                description: \`Invalid username/password supplied\`,
+                schema: z.void(),
+              },
+            ],
+          },
+          {
+            method: "get",
+            path: "/user/logout",
+            requestFormat: "json",
+            response: z.void(),
+          },
+        ]);
+
+        export const api = new Zodios(endpoints);
+
+        export function createApiClient(baseUrl: string, options?: ZodiosOptions) {
+          return new Zodios(baseUrl, endpoints, options);
+        }
+        "
+      `);
     });
 });
 

--- a/lib/src/generateZodClientFromOpenAPI.test.ts
+++ b/lib/src/generateZodClientFromOpenAPI.test.ts
@@ -3468,7 +3468,7 @@ describe.only("generateZodClientFromOpenAPI", () => {
             disableWriteToFile: true,
             options: { groupStrategy: "tag-file" },
         });
-        expect(prettyOutput).toMatchInlineSnapshot(`
+        expect(prettyOutput["pet"]).toMatchInlineSnapshot(`
         "import { makeApi, Zodios, type ZodiosOptions } from "@zodios/core";
         import { z } from "zod";
 
@@ -3494,38 +3494,12 @@ describe.only("generateZodClientFromOpenAPI", () => {
           .object({ code: z.number().int(), type: z.string(), message: z.string() })
           .partial()
           .passthrough();
-        const Order = z
-          .object({
-            id: z.number().int(),
-            petId: z.number().int(),
-            quantity: z.number().int(),
-            shipDate: z.string().datetime({ offset: true }),
-            status: z.enum(["placed", "approved", "delivered"]),
-            complete: z.boolean(),
-          })
-          .partial()
-          .passthrough();
-        const User = z
-          .object({
-            id: z.number().int(),
-            username: z.string(),
-            firstName: z.string(),
-            lastName: z.string(),
-            email: z.string(),
-            password: z.string(),
-            phone: z.string(),
-            userStatus: z.number().int(),
-          })
-          .partial()
-          .passthrough();
 
         export const schemas = {
+          Pet,
           Category,
           Tag,
-          Pet,
           ApiResponse,
-          Order,
-          User,
         };
 
         const endpoints = makeApi([
@@ -3579,6 +3553,51 @@ describe.only("generateZodClientFromOpenAPI", () => {
               {
                 status: 405,
                 description: \`Invalid input\`,
+                schema: z.void(),
+              },
+            ],
+          },
+          {
+            method: "get",
+            path: "/pet/findByStatus",
+            description: \`Multiple status values can be provided with comma separated strings\`,
+            requestFormat: "json",
+            parameters: [
+              {
+                name: "status",
+                type: "Query",
+                schema: z
+                  .enum(["available", "pending", "sold"])
+                  .optional()
+                  .default("available"),
+              },
+            ],
+            response: z.array(Pet),
+            errors: [
+              {
+                status: 400,
+                description: \`Invalid status value\`,
+                schema: z.void(),
+              },
+            ],
+          },
+          {
+            method: "get",
+            path: "/pet/findByTags",
+            description: \`Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.\`,
+            requestFormat: "json",
+            parameters: [
+              {
+                name: "tags",
+                type: "Query",
+                schema: z.array(z.string()).optional(),
+              },
+            ],
+            response: z.array(Pet),
+            errors: [
+              {
+                status: 400,
+                description: \`Invalid tag value\`,
                 schema: z.void(),
               },
             ],
@@ -3688,265 +3707,9 @@ describe.only("generateZodClientFromOpenAPI", () => {
             ],
             response: ApiResponse,
           },
-          {
-            method: "get",
-            path: "/pet/findByStatus",
-            description: \`Multiple status values can be provided with comma separated strings\`,
-            requestFormat: "json",
-            parameters: [
-              {
-                name: "status",
-                type: "Query",
-                schema: z
-                  .enum(["available", "pending", "sold"])
-                  .optional()
-                  .default("available"),
-              },
-            ],
-            response: z.array(Pet),
-            errors: [
-              {
-                status: 400,
-                description: \`Invalid status value\`,
-                schema: z.void(),
-              },
-            ],
-          },
-          {
-            method: "get",
-            path: "/pet/findByTags",
-            description: \`Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.\`,
-            requestFormat: "json",
-            parameters: [
-              {
-                name: "tags",
-                type: "Query",
-                schema: z.array(z.string()).optional(),
-              },
-            ],
-            response: z.array(Pet),
-            errors: [
-              {
-                status: 400,
-                description: \`Invalid tag value\`,
-                schema: z.void(),
-              },
-            ],
-          },
-          {
-            method: "get",
-            path: "/store/inventory",
-            description: \`Returns a map of status codes to quantities\`,
-            requestFormat: "json",
-            response: z.record(z.number()),
-          },
-          {
-            method: "post",
-            path: "/store/order",
-            description: \`Place a new order in the store\`,
-            requestFormat: "json",
-            parameters: [
-              {
-                name: "body",
-                type: "Body",
-                schema: Order,
-              },
-            ],
-            response: Order,
-            errors: [
-              {
-                status: 405,
-                description: \`Invalid input\`,
-                schema: z.void(),
-              },
-            ],
-          },
-          {
-            method: "get",
-            path: "/store/order/:orderId",
-            description: \`For valid response try integer IDs with value &lt;&#x3D; 5 or &gt; 10. Other values will generate exceptions.\`,
-            requestFormat: "json",
-            parameters: [
-              {
-                name: "orderId",
-                type: "Path",
-                schema: z.number().int(),
-              },
-            ],
-            response: Order,
-            errors: [
-              {
-                status: 400,
-                description: \`Invalid ID supplied\`,
-                schema: z.void(),
-              },
-              {
-                status: 404,
-                description: \`Order not found\`,
-                schema: z.void(),
-              },
-            ],
-          },
-          {
-            method: "delete",
-            path: "/store/order/:orderId",
-            description: \`For valid response try integer IDs with value &lt; 1000. Anything above 1000 or nonintegers will generate API errors\`,
-            requestFormat: "json",
-            parameters: [
-              {
-                name: "orderId",
-                type: "Path",
-                schema: z.number().int(),
-              },
-            ],
-            response: z.void(),
-            errors: [
-              {
-                status: 400,
-                description: \`Invalid ID supplied\`,
-                schema: z.void(),
-              },
-              {
-                status: 404,
-                description: \`Order not found\`,
-                schema: z.void(),
-              },
-            ],
-          },
-          {
-            method: "post",
-            path: "/user",
-            description: \`This can only be done by the logged in user.\`,
-            requestFormat: "json",
-            parameters: [
-              {
-                name: "body",
-                description: \`Created user object\`,
-                type: "Body",
-                schema: User,
-              },
-            ],
-            response: z.void(),
-          },
-          {
-            method: "get",
-            path: "/user/:username",
-            requestFormat: "json",
-            parameters: [
-              {
-                name: "username",
-                type: "Path",
-                schema: z.string(),
-              },
-            ],
-            response: User,
-            errors: [
-              {
-                status: 400,
-                description: \`Invalid username supplied\`,
-                schema: z.void(),
-              },
-              {
-                status: 404,
-                description: \`User not found\`,
-                schema: z.void(),
-              },
-            ],
-          },
-          {
-            method: "put",
-            path: "/user/:username",
-            description: \`This can only be done by the logged in user.\`,
-            requestFormat: "json",
-            parameters: [
-              {
-                name: "body",
-                description: \`Update an existent user in the store\`,
-                type: "Body",
-                schema: User,
-              },
-              {
-                name: "username",
-                type: "Path",
-                schema: z.string(),
-              },
-            ],
-            response: z.void(),
-          },
-          {
-            method: "delete",
-            path: "/user/:username",
-            description: \`This can only be done by the logged in user.\`,
-            requestFormat: "json",
-            parameters: [
-              {
-                name: "username",
-                type: "Path",
-                schema: z.string(),
-              },
-            ],
-            response: z.void(),
-            errors: [
-              {
-                status: 400,
-                description: \`Invalid username supplied\`,
-                schema: z.void(),
-              },
-              {
-                status: 404,
-                description: \`User not found\`,
-                schema: z.void(),
-              },
-            ],
-          },
-          {
-            method: "post",
-            path: "/user/createWithList",
-            description: \`Creates list of users with given input array\`,
-            requestFormat: "json",
-            parameters: [
-              {
-                name: "body",
-                type: "Body",
-                schema: z.array(User),
-              },
-            ],
-            response: User,
-          },
-          {
-            method: "get",
-            path: "/user/login",
-            requestFormat: "json",
-            parameters: [
-              {
-                name: "username",
-                type: "Query",
-                schema: z.string().optional(),
-              },
-              {
-                name: "password",
-                type: "Query",
-                schema: z.string().optional(),
-              },
-            ],
-            response: z.string(),
-            errors: [
-              {
-                status: 400,
-                description: \`Invalid username/password supplied\`,
-                schema: z.void(),
-              },
-            ],
-          },
-          {
-            method: "get",
-            path: "/user/logout",
-            requestFormat: "json",
-            response: z.void(),
-          },
         ]);
 
-        export const api = new Zodios(endpoints);
+        export const PetApi = new Zodios(endpoints);
 
         export function createApiClient(baseUrl: string, options?: ZodiosOptions) {
           return new Zodios(baseUrl, endpoints, options);

--- a/lib/src/generateZodClientFromOpenAPI.test.ts
+++ b/lib/src/generateZodClientFromOpenAPI.test.ts
@@ -2970,7 +2970,7 @@ describe("generateZodClientFromOpenAPI", () => {
         `);
     });
 
-    test("with tag-file option", async () => {
+    test("without default values", async () => {
         const prettyOutput = await generateZodClientFromOpenAPI({
             openApiDoc,
             disableWriteToFile: true,

--- a/lib/src/generateZodClientFromOpenAPI.test.ts
+++ b/lib/src/generateZodClientFromOpenAPI.test.ts
@@ -3462,7 +3462,7 @@ describe.only("generateZodClientFromOpenAPI", () => {
         `);
     });
 
-    test.only("without options", async () => {
+    test.only("with tag-file groupStrategy", async () => {
         const prettyOutput = await generateZodClientFromOpenAPI({
             openApiDoc,
             disableWriteToFile: true,

--- a/lib/src/generateZodClientFromOpenAPI.test.ts
+++ b/lib/src/generateZodClientFromOpenAPI.test.ts
@@ -463,7 +463,7 @@ test("getZodClientTemplateContext", async () => {
     `);
 });
 
-describe.only("generateZodClientFromOpenAPI", () => {
+describe("generateZodClientFromOpenAPI", () => {
     test("without options", async () => {
         const prettyOutput = await generateZodClientFromOpenAPI({ openApiDoc, disableWriteToFile: true });
         expect(prettyOutput).toMatchInlineSnapshot(`
@@ -3462,7 +3462,7 @@ describe.only("generateZodClientFromOpenAPI", () => {
         `);
     });
 
-    test.only("with tag-file groupStrategy", async () => {
+    test("with tag-file groupStrategy", async () => {
         const prettyOutput = await generateZodClientFromOpenAPI({
             openApiDoc,
             disableWriteToFile: true,
@@ -3496,9 +3496,9 @@ describe.only("generateZodClientFromOpenAPI", () => {
           .passthrough();
 
         export const schemas = {
-          Pet,
           Category,
           Tag,
+          Pet,
           ApiResponse,
         };
 

--- a/lib/src/template-context.ts
+++ b/lib/src/template-context.ts
@@ -187,11 +187,11 @@ export const getZodClientTemplateContext = (
                 }
             });
 
-            group.schemas = sortObjKeysFromArray(groupSchemas, schemaOrderedByDependencies);
+            group.schemas = sortObjKeysFromArray(groupSchemas, getPureSchemaNames(schemaOrderedByDependencies));
             group.types = groupTypes;
         });
         data.commonSchemaNames = new Set(
-            sortListFromRefArray(Array.from(commonSchemaNames), schemaOrderedByDependencies)
+            sortListFromRefArray(Array.from(commonSchemaNames), getPureSchemaNames(schemaOrderedByDependencies))
         );
     }
 
@@ -215,6 +215,12 @@ const makeTemplateContext = (): TemplateContext => {
 
 const originalPathParam = /:(\w+)/g;
 const getOriginalPathWithBrackets = (path: string) => path.replaceAll(originalPathParam, "{$1}");
+// Example full schema name is like: #/components/schemas/Category.
+// We only want to get the "Category".
+//
+// This is because when using `sortObjKeysFromArray`, the string array needs to be exactly the same
+// like the object keys. Otherwise, the object keys won't be re-ordered.
+const getPureSchemaNames = (fullSchemaNames: string[]) => fullSchemaNames.map((name) => name.split("/").at(-1)!);
 
 export type TemplateContext = {
     schemas: Record<string, string>;

--- a/lib/tests/group-strategy.test.ts
+++ b/lib/tests/group-strategy.test.ts
@@ -550,7 +550,7 @@ test("group-strategy", async () => {
     `);
 });
 
-test("group-strategy with complex schemas + split files", async () => {
+test.only("group-strategy with complex schemas + split files", async () => {
     const openApiDoc: OpenAPIObject = {
         openapi: "3.0.3",
         info: { version: "1", title: "Example API" },
@@ -1003,6 +1003,17 @@ test("group-strategy with complex schemas + split files", async () => {
         store_list: Array<Store>;
       }>;
 
+      const Country: z.ZodType<Country> = z.lazy(() =>
+        z
+          .object({
+            id: z.number().int(),
+            name: z.string(),
+            code: z.string(),
+            store_list: z.array(Store),
+          })
+          .partial()
+          .passthrough()
+      );
       const Store: z.ZodType<Store> = z.lazy(() =>
         z
           .object({
@@ -1015,21 +1026,10 @@ test("group-strategy with complex schemas + split files", async () => {
           .partial()
           .passthrough()
       );
-      const Country: z.ZodType<Country> = z.lazy(() =>
-        z
-          .object({
-            id: z.number().int(),
-            name: z.string(),
-            code: z.string(),
-            store_list: z.array(Store),
-          })
-          .partial()
-          .passthrough()
-      );
 
       export const schemas = {
-        Store,
         Country,
+        Store,
       };
 
       const endpoints = makeApi([

--- a/lib/tests/group-strategy.test.ts
+++ b/lib/tests/group-strategy.test.ts
@@ -550,7 +550,7 @@ test("group-strategy", async () => {
     `);
 });
 
-test.only("group-strategy with complex schemas + split files", async () => {
+test("group-strategy with complex schemas + split files", async () => {
     const openApiDoc: OpenAPIObject = {
         openapi: "3.0.3",
         info: { version: "1", title: "Example API" },


### PR DESCRIPTION
This PR is a PoC to proof that when using `groupStrategy: "tag-file"`, the zod type of `Category` and `Tag` are generated last instead of first.

```diff
- const Category = z
-   .object({ id: z.number().int(), name: z.string() })
-   .partial()
-   .passthrough();
- const Tag = z
-   .object({ id: z.number().int(), name: z.string() })
-   .partial()
-   .passthrough();
  const Pet = z
    .object({
      id: z.number().int().optional(),
      name: z.string(),
--
      tags: z.array(Tag).optional(),
      status: z.enum(["available", "pending", "sold"]).optional(),
    })
    .passthrough();
+ const Category = z
+   .object({ id: z.number().int(), name: z.string() })
+   .partial()
+   .passthrough();
+ const Tag = z
+   .object({ id: z.number().int(), name: z.string() })
+   .partial()
+   .passthrough();
  const ApiResponse = z
    .object({ code: z.number().int(), type: z.string(), message: z.string() })
    .partial()
    .passthrough();
```

As we see above, since `Pet` is declared first, then it will cause error since `Category` and `Tag` isn't defined yet. I'll create an issue for this, referring to this PR.