### PR TITLE
feat: reduce dependency count threshold for a type to be imported from common file to just 1

### DIFF
--- a/.changeset/seven-hotels-raise.md
+++ b/.changeset/seven-hotels-raise.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": minor
+---
+
+feat: reduce dependency count threshold for a type to be imported from common file to just 1

--- a/lib/src/template-context.ts
+++ b/lib/src/template-context.ts
@@ -175,7 +175,7 @@ export const getZodClientTemplateContext = (
             const groupTypes = {} as Record<string, string>;
             Object.entries(group.schemas).forEach(([name, schema]) => {
                 const count = dependenciesCount.get(name) ?? 0;
-                if (count > 1) {
+                if (count >= 1) {
                     group.imports![name] = "common";
                     commonSchemaNames.add(name);
                 } else {


### PR DESCRIPTION
Closes https://github.com/astahmer/openapi-zod-client/issues/186. Previously, in order for files to be moved to a common file, it needs to be imported/referenced at least 2 or more.

In this PR, it's reduced to at least 1. I have also updated one existing test for this effort, as well as creating one with example PetStore YAML -- basically making `Order` to depend on `Pet`. It resulted in `Pet`, `Category`, and `Tag` to be extracted to a common file, which is exactly the behavior proposed in the issue.

Let me know if you have concerns about this approach, thanks!