### PR TITLE
Add `camelCase` formatting helper to `hbs` files.

### DIFF
--- a/.changeset/support_camel_case_formatting_in_hbs.md
+++ b/.changeset/support_camel_case_formatting_in_hbs.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": patch
+---
+
+Add `camelCase` formatting to `hbs` files.

--- a/lib/src/getHandlebars.ts
+++ b/lib/src/getHandlebars.ts
@@ -21,6 +21,18 @@ export const getHandlebars = () => {
         // @ts-expect-error
         return options.inverse(this);
     });
+    instance.registerHelper("toCamelCase", function (input: string) {
+        const words = input.split(/[\s_-]/);
+        return words
+            .map((word, index) => {
+                if (index === 0) {
+                    return word.toLowerCase();
+                }
+
+                return word.charAt(0).toUpperCase() + word.slice(1).toLowerCase();
+            })
+            .join("");
+    });
 
     return instance;
 };


### PR DESCRIPTION
Add `camelCase` formatting helper to `hbs` files.

Related issue:
https://github.com/astahmer/openapi-zod-client/issues/201