### PR TITLE
Export only object types with --export-types flag, fix boolean options in playground

### DIFF
--- a/.changeset/blue-ways-change.md
+++ b/.changeset/blue-ways-change.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": patch
+---
+
+Limit --export-types to object types to prevent type errors from zod validation methods like `.min`

--- a/lib/src/cli.ts
+++ b/lib/src/cli.ts
@@ -49,7 +49,7 @@ cli.command("<input>", "path/url to OpenAPI/Swagger document as json/yaml")
         "--default-status",
         "when defined as `auto-correct`, will automatically use `default` as fallback for `response` when no status code was declared"
     )
-    .option("--export-types", "When true, will defined types for all schemas in `#/components/schemas`")
+    .option("--export-types", "When true, will defined types for all object schemas in `#/components/schemas`")
     .action(async (input, options) => {
         console.log("Retrieving OpenAPI document from", input);
         const openApiDoc = (await SwaggerParser.bundle(input)) as OpenAPIObject;

--- a/playground/src/Playground/Playground.tsx
+++ b/playground/src/Playground/Playground.tsx
@@ -556,7 +556,10 @@ const OptionsDrawer = () => {
                                 onChange={(update) =>
                                     send({ type: "Update preview options", options: update as OptionsFormValues })
                                 }
-                                onSubmit={(values) => send({ type: "Save options", options: values })}
+                                onSubmit={(values) => {
+                                    const booleanOptions = getRelevantOptions(values);
+                                    send({ type: "Save options", options: { ...values, ...booleanOptions } });
+                                }}
                                 defaultValues={state.context.previewOptions}
                             />
                         </Panel>

--- a/playground/src/Playground/Playground.tsx
+++ b/playground/src/Playground/Playground.tsx
@@ -613,6 +613,7 @@ const optionNameToCliOptionName = {
     isErrorStatus: "--error-expr",
     isMainResponseStatus: "--success-expr",
     shouldExportAllSchemas: "--export-schemas",
+    shouldExportAllTypes: "--export-types",
     isMediaTypeAllowed: "--media-type-expr",
     withImplicitRequiredProps: "--implicit-required",
     withDeprecatedEndpoints: "--with-deprecated",


### PR DESCRIPTION
With the new --export-types flag, all schema are defined as TS types as well. The schema definition included a type assignment to the generated type. This is useful for schemas that are too large for TS to infer like deeply nested objects.
OpenApi supports `minimum`, `maximum`, `minLength`, `minItems`, etc. which are transpiled to the zod `.min()`, `.max()`, etc. methods on the schema.
These methods are not supported on `z.ZodType` types which causes a TS error when schemas are a non-object type and have these validation attributes on them.
This PR limits the OpenApi types for which non-circular types will be generated when `--export-types` is passed to only `object` types.

Additionally, the boolean lib option in the playground has been broken. This PR properly sets booleans in options when the lib options are saved. 