### PR TITLE
Fix: Handlebars helper toCamelCase should not touch the string if it's already in camel case.

### DIFF
--- a/.changeset/to_camel_case_check.md
+++ b/.changeset/to_camel_case_check.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": patch
+---
+
+Handlebars helper `toCamelCase` should not touch the string if it's already in camel case.

--- a/lib/src/getHandlebars.ts
+++ b/lib/src/getHandlebars.ts
@@ -22,6 +22,11 @@ export const getHandlebars = () => {
         return options.inverse(this);
     });
     instance.registerHelper("toCamelCase", function (input: string) {
+        // Check if input string is already in camelCase
+        if (/^[a-z][a-zA-Z0-9]*$/.test(input)) {
+            return input
+        }
+
         const words = input.split(/[\s_-]/);
         return words
             .map((word, index) => {


### PR DESCRIPTION
Related issue:
https://github.com/astahmer/openapi-zod-client/issues/218