### PR TITLE
Add support for null value in enums when using `--export-types`

### DIFF
--- a/lib/src/openApiToTypescript.ts
+++ b/lib/src/openApiToTypescript.ts
@@ -163,7 +163,9 @@ TsConversionArgs): ts.Node | TypeDefinitionObject | string => {
                     return schema.nullable ? t.union([t.never(), t.reference("null")]) : t.never();
                 }
 
-                return schema.nullable ? t.union([...schema.enum, t.reference("null")]) : t.union(schema.enum);
+                const hasNull = schema.enum.includes(null);
+                const withoutNull = schema.enum.filter(f => f !== null);
+                return schema.nullable || hasNull ? t.union([...withoutNull, t.reference("null")]) : t.union(withoutNull);
             }
 
             if (schemaType === "string")

--- a/lib/src/openApiToZod.ts
+++ b/lib/src/openApiToZod.ts
@@ -155,7 +155,7 @@ export function getZodSchema({ schema, ctx, meta: inheritedMeta, options }: Conv
                 }
 
                 // eslint-disable-next-line sonarjs/no-nested-template-literals
-                return code.assign(`z.enum([${schema.enum.map((value) => `"${value}"`).join(", ")}])`);
+                return code.assign(`z.enum([${schema.enum.map((value) => value === null ? "null" : `"${value}"`).join(", ")}])`);
             }
 
             if (schema.enum.some((e) => typeof e === "string")) {

--- a/lib/tests/enum-null.test.ts
+++ b/lib/tests/enum-null.test.ts
@@ -1,0 +1,177 @@
+import type { OpenAPIObject } from "openapi3-ts";
+import { expect, test } from "vitest";
+import { generateZodClientFromOpenAPI } from "../src";
+
+// https://github.com/astahmer/openapi-zod-client/issues/61
+test("enum-null", async () => {
+    const openApiDoc: OpenAPIObject = {
+        openapi: "3.0.0",
+        info: {
+            version: "1.0.0",
+            title: "enum null",
+        },
+        components: {
+            schemas: {
+                "Null1": {
+                    type: "string",
+                    enum: [null],
+                },
+                "Null2": {
+                    type: "string",
+                    enum: ["a", null],
+                },
+                "Null3": {
+                    type: "string",
+                    enum: ["a", null],
+                    nullable: true
+                },
+                "Null4": {
+                    type: "string",
+                    enum: [null],
+                    nullable: true
+                },
+                "Compound": {
+                    type: "object",
+                    properties: {
+                        "field": {
+                            oneOf: [
+                                { $ref: '#/components/schemas/Null1' },
+                                { $ref: '#/components/schemas/Null2' },
+                                { $ref: '#/components/schemas/Null3' },
+                                { $ref: '#/components/schemas/Null4' },
+                                { type: "string" }
+                            ]
+                        }
+                    }
+                }
+            }
+        },
+        paths: {
+            "/sample": {
+                get: {
+                    responses: {
+                        "200": {
+                            description: "one null",
+                            content: {
+                                "application/json": {
+                                    schema: {
+                                        $ref: "#/components/schemas/Null1",
+                                    }
+                                }
+                            }
+                        },
+                        "400": {
+                            description: "null with a string",
+                            content: {
+                                "application/json": {
+                                    schema: {
+                                        $ref: "#/components/schemas/Null2",
+                                    }
+                                }
+                            }
+                        },
+                        "401": {
+                            description: "null with a string and nullable",
+                            content: {
+                                "application/json": {
+                                    schema: {
+                                        $ref: "#/components/schemas/Null3",
+                                    }
+                                }
+                            }
+                        },
+                        "402": {
+                            description: "null with nullable",
+                            content: {
+                                "application/json": {
+                                    schema: {
+                                        $ref: "#/components/schemas/Null4",
+                                    }
+                                }
+                            }
+                        },
+                        "403": {
+                            description: "object that references null",
+                            content: {
+                                "application/json": {
+                                    schema: {
+                                        $ref: "#/components/schemas/Compound",
+                                    }
+                                }
+                            }
+                        },
+                    },
+                },
+            },
+        },
+    };
+
+    const output = await generateZodClientFromOpenAPI({ disableWriteToFile: true, openApiDoc, options: { shouldExportAllTypes: true } });
+    expect(output).toMatchInlineSnapshot(`
+      "import { makeApi, Zodios, type ZodiosOptions } from "@zodios/core";
+      import { z } from "zod";
+
+      type Compound = Partial<{
+        field: Null1 | Null2 | Null3 | Null4 | string;
+      }>;
+      type Null1 = null;
+      type Null2 = "a" | null;
+      type Null3 = "a" | null;
+      type Null4 = null;
+
+      const Null1 = z.literal(null);
+      const Null2 = z.enum(["a", null]);
+      const Null3 = z.enum(["a", null]);
+      const Null4 = z.literal(null);
+      const Compound: z.ZodType<Compound> = z
+        .object({ field: z.union([Null1, Null2, Null3, Null4, z.string()]) })
+        .partial()
+        .passthrough();
+
+      export const schemas = {
+        Null1,
+        Null2,
+        Null3,
+        Null4,
+        Compound,
+      };
+
+      const endpoints = makeApi([
+        {
+          method: "get",
+          path: "/sample",
+          requestFormat: "json",
+          response: z.literal(null),
+          errors: [
+            {
+              status: 400,
+              description: \`null with a string\`,
+              schema: z.enum(["a", null]),
+            },
+            {
+              status: 401,
+              description: \`null with a string and nullable\`,
+              schema: z.enum(["a", null]).nullable(),
+            },
+            {
+              status: 402,
+              description: \`null with nullable\`,
+              schema: z.literal(null).nullable(),
+            },
+            {
+              status: 403,
+              description: \`object that references null\`,
+              schema: Compound,
+            },
+          ],
+        },
+      ]);
+
+      export const api = new Zodios(endpoints);
+
+      export function createApiClient(baseUrl: string, options?: ZodiosOptions) {
+        return new Zodios(baseUrl, endpoints, options);
+      }
+      "
+    `);
+});


### PR DESCRIPTION
[OpenAPI 3.0.3 Data Types](https://spec.openapis.org/oas/v3.0.3#data-types) are defined by [JSON Schema Specification Wright Draft 00](https://datatracker.ietf.org/doc/html/draft-wright-json-schema-00#section-4.2).

However, the specification mentions that "null is not supported as a type" and the `nullable` keyword should be used instead. While it is a valid solution in most cases, it is not possible to use `nullable` together with `$ref`. One possible workaround is to define a Null schema and use it in combination with `oneOf`, like so:

```json
{
  "oneOf": [
    { "$ref": "#/components/schemas/MySchema" },
    {
      "type": "string",
      "enum": [null],
      "nullable": true
    }
  ]
}
```

It may look contradictory, but according to the [enum section of JSON Schema Validation Wright Draft 00](https://datatracker.ietf.org/doc/html/draft-wright-json-schema-validation-00#section-5.20):

> The value of this keyword MUST be an array.  This array SHOULD have
> at least one element.  Elements in the array SHOULD be unique.
> 
> Elements in the array MAY be of any type, including null.
> 
> An instance validates successfully against this keyword if its value
> is equal to one of the elements in this keyword's array value.

This means that `null` is a possible value for the "enum" validation of "type" "string".

This schema also passes the `swagger-cli validate` check.

The openapi-zod-client library currently crashes when generating a TypeScript type for this construct. Additionally, the generated zod schemas are not correct when using a `null` value in "enum" along with other values. This PR fixes that.

