### PR TITLE
fix: pass options when shouldExportAllSchemas is true

### DIFF
--- a/.changeset/options-passed-when-shouldExportAllSchemas.md
+++ b/.changeset/options-passed-when-shouldExportAllSchemas.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": patch
+---
+
+Pass options object to `getZodSchema` when `shouldExportAllSchemas` is true.

--- a/lib/src/template-context.ts
+++ b/lib/src/template-context.ts
@@ -33,7 +33,7 @@ export const getZodClientTemplateContext = (
     if (options?.shouldExportAllSchemas) {
         Object.entries(docSchemas).forEach(([name, schema]) => {
             if (!result.zodSchemaByName[name]) {
-                result.zodSchemaByName[name] = getZodSchema({ schema, ctx: result }).toString();
+                result.zodSchemaByName[name] = getZodSchema({ schema, ctx: result, options }).toString();
             }
         });
     }


### PR DESCRIPTION
Following latest update, I realized `options` are not passed to `getZodSchema` when `shouldExportAllSchemas` is true, resulting with `.passthrough()` on schemas even if `additionalPropertiesDefaultValue: false` is passed.

If this is too risky, I can only pass `additionalPropertiesDefaultValue` to options if needed.