### PR TITLE
feat: allow x-zod-schema for convenient "features"

### DIFF
--- a/lib/src/cli.ts
+++ b/lib/src/cli.ts
@@ -52,6 +52,7 @@ cli.command("<input>", "path/url to OpenAPI/Swagger document as json/yaml")
     .option("--all-readonly", "when true, all generated objects and arrays will be readonly")
     .option("--export-types", "When true, will defined types for all object schemas in `#/components/schemas`")
     .option("--additional-props-default-value", "Set default value when additionalProperties is not provided. Default to true.", { default: true })
+    .option('--x-zod-schema', "When true, allows using x-zod-schema property to generate zod schema for a given openapi schema.")
     .action(async (input, options) => {
         console.log("Retrieving OpenAPI document from", input);
         const openApiDoc = (await SwaggerParser.bundle(input)) as OpenAPIObject;
@@ -82,7 +83,8 @@ cli.command("<input>", "path/url to OpenAPI/Swagger document as json/yaml")
                 defaultStatusBehavior: options.defaultStatus,
                 withDescription: options.withDescription,
                 allReadonly: options.allReadonly,
-                additionalPropertiesDefaultValue: options.additionalPropsDefaultValue
+                additionalPropertiesDefaultValue: options.additionalPropsDefaultValue,
+                xZodSchema: options.xZodSchema,
             },
         });
         console.log(`Done generating <${distPath}> !`);

--- a/lib/src/openApiToZod.ts
+++ b/lib/src/openApiToZod.ts
@@ -63,6 +63,14 @@ export function getZodSchema({ schema, ctx, meta: inheritedMeta, options }: Conv
         return code;
     }
 
+    if (options?.xZodSchema) {
+        const xZodSchema = schema["x-zod-schema"];
+        if (xZodSchema) {
+            return code.assign(xZodSchema);
+        }
+    }
+
+
     if (Array.isArray(schema.type)) {
         if (schema.type.length === 1) {
             return getZodSchema({ schema: { ...schema, type: schema.type[0]! }, ctx, meta, options });

--- a/lib/src/template-context.ts
+++ b/lib/src/template-context.ts
@@ -387,4 +387,9 @@ export type TemplateContextOptions = {
      * When true, returns a "responses" array with all responses (both success and errors)
      */
     withAllResponses?: boolean;
+
+    /**
+     * When true, supports `x-zod-schema` to define the complete zod schema for a given openapi schema. 
+     */
+    xZodSchema?: boolean;
 };


### PR DESCRIPTION
### What it does
Allows the user to override the zod schema generated for an openapi schema via an extension property:
```yml
NullableDateTime:
      description: Date and time in ISO 8601 format, or null.
      type: [string, "null"]
      format: date-time
      x-zod-schema: z.coerce.date().nullable()
```
This should generate:
```ts
const NullableDateTime = z.coerce.date().nullable();
```
### Enable It Via
The new CLI option: `--x-zod-schema`.

### Reasoning
Tweaking the generated client via only handlebars is... quite limiting. In cases where there is a conflict between the spec author/developer and the openapi-zod-client plugin in terms of what should be generated, or when the generator turns out to be inflexible, this extension can provide a much cheaper alternative to forking the project.

Take my example above: I wanted coercion on my date types because js Date class is what I like to use in my form components. That's not possible out of the box with the plugin. In fact, I dropped my attempt at modifying the library to add an option for coercions halfway through and wrote this instead.