### PR TITLE
chore: make endpointDefinitionRefiner to receive final fields that are going to be used in handlebars

### DIFF
--- a/.changeset/little-shirts-fly.md
+++ b/.changeset/little-shirts-fly.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": patch
+---
+
+chore: make endpointDefinitionRefiner to receive final fields that are going to be used in handlebars

--- a/lib/src/getZodiosEndpointDefinitionList.ts
+++ b/lib/src/getZodiosEndpointDefinitionList.ts
@@ -162,12 +162,6 @@ export const getZodiosEndpointDefinitionList = (doc: OpenAPIObject, options?: Te
                 response: "",
             };
 
-            if (options?.endpointDefinitionRefiner) {
-                // Refine the endpoint definition, in case consumer wants to add some specific fields
-                // to be rendered in the Handlebars template.
-                endpointDefinition = options.endpointDefinitionRefiner(endpointDefinition, operation);
-            }
-
             if (operation.requestBody) {
                 const requestBody = (
                     isReferenceObject(operation.requestBody)
@@ -387,6 +381,12 @@ export const getZodiosEndpointDefinitionList = (doc: OpenAPIObject, options?: Te
 
             if (!endpointDefinition.response) {
                 endpointDefinition.response = voidSchema;
+            }
+
+            if (options?.endpointDefinitionRefiner) {
+                // Refine the endpoint definition, in case consumer wants to add some specific fields
+                // to be rendered in the Handlebars template.
+                endpointDefinition = options.endpointDefinitionRefiner(endpointDefinition, operation);
             }
 
             endpoints.push(endpointDefinition);


### PR DESCRIPTION
Closes https://github.com/astahmer/openapi-zod-client/issues/241. This PR updates the location where `endpointDefinitionRefiner` is going to be called.

Previously, it's called when the endpoint definition is still empty, but now it's placed where all fields have been filled accordingly.