### PR TITLE
fix: wrap properties beginning with a number in quotes

### DIFF
--- a/lib/src/utils.ts
+++ b/lib/src/utils.ts
@@ -15,7 +15,7 @@ export function normalizeString(text: string) {
 }
 
 export const wrapWithQuotesIfNeeded = (str: string) => {
-    if (/^\w+$/.test(str)) {
+    if (/^[a-zA-Z]\w*$/.test(str)) {
         return str;
     }
 


### PR DESCRIPTION
When a property starts with a number, e.g. `1st`, instead of `first`, the generated Zod-Schema is corrupt. 

The change in the wrapWithQuotesIfNeeded method makes sure, that any property starting with a number is wrapped in quotes.