### PR TITLE
fix: convert additionalPropsDefaultValue to bool

### DIFF
--- a/.changeset/fix-additional-props-default-value-as-string.md
+++ b/.changeset/fix-additional-props-default-value-as-string.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": patch
+---
+
+Fixes an issue whereby you aren't able to set additionalPropsDefaultValue from command line as false because the package expects it to be a boolean, however recieves a string value

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Options:
   --default-status          when defined as `auto-correct`, will automatically use `default` as fallback for `response` when no status code was declared 
   --all-readonly            when true, all generated objects and arrays will be readonly 
   --export-types            When true, will defined types for all object schemas in `#/components/schemas` 
+  --additional-props-default-value  Set default value when additionalProperties is not provided. Default to true. (default: true)
   -v, --version             Display version number 
   -h, --help                Display this message
 ```

--- a/lib/src/cli.ts
+++ b/lib/src/cli.ts
@@ -6,8 +6,8 @@ import cac from "cac";
 import type { OpenAPIObject } from "openapi3-ts";
 import { safeJSONParse } from "pastable/server";
 import { resolveConfig } from "prettier";
-import { match, P } from "ts-pattern";
 
+import { toBoolean } from "./utils";
 import { generateZodClientFromOpenAPI } from "./generateZodClientFromOpenAPI";
 
 const cli = cac("openapi-zod-client");
@@ -57,9 +57,8 @@ cli.command("<input>", "path/url to OpenAPI/Swagger document as json/yaml")
         const openApiDoc = (await SwaggerParser.bundle(input)) as OpenAPIObject;
         const prettierConfig = await resolveConfig(options.prettier || "./");
         const distPath = options.output || input + ".client.ts";
-        const withAlias = match(options.withAlias)
-            .with(P.nullish, P.string.regex(/^false$/i), false, () => false)
-            .otherwise(() => true);
+        const withAlias = toBoolean(options.withAlias, true)
+        const additionalPropertiesDefaultValue = toBoolean(options.additionalPropsDefaultValue, true)
 
         await generateZodClientFromOpenAPI({
             openApiDoc,
@@ -82,7 +81,7 @@ cli.command("<input>", "path/url to OpenAPI/Swagger document as json/yaml")
                 defaultStatusBehavior: options.defaultStatus,
                 withDescription: options.withDescription,
                 allReadonly: options.allReadonly,
-                additionalPropertiesDefaultValue: options.additionalPropsDefaultValue
+                additionalPropertiesDefaultValue
             },
         });
         console.log(`Done generating <${distPath}> !`);

--- a/lib/src/utils.ts
+++ b/lib/src/utils.ts
@@ -1,5 +1,6 @@
 import type { SchemaObject } from "openapi3-ts";
 import { capitalize, kebabToCamel, snakeToCamel } from "pastable/server";
+import { match, P } from "ts-pattern";
 
 export const asComponentSchema = (name: string) => `#/components/schemas/${name}`;
 
@@ -80,3 +81,8 @@ export const escapeControlCharacters = (str: string): string => {
             return `\\u${`0000${hex}`.slice(-4)}`;
         });
 };
+
+export const toBoolean = (value: undefined | string | boolean, defaultValue: boolean) => match(value)
+    .with(P.string.regex(/^false$/i), false, () => false)
+    .with(P.string.regex(/^true$/i), true, () => true)
+    .otherwise(() => defaultValue);

--- a/lib/tests/utils.test.ts
+++ b/lib/tests/utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, test, expect } from "vitest";
+import { toBoolean } from "../src/utils";
+
+describe("toBoolean", () => {
+  test("returns boolean true, when string value 'true'", () => {
+    expect(toBoolean("true", false)).toEqual(true);
+  });
+
+  test("returns boolean false, when string value 'false'", () => {
+    expect(toBoolean("false", true)).toEqual(false);
+  });
+
+  test("returns default boolean value, when empty string is present", () => {
+    expect(toBoolean("", true)).toEqual(true);
+    expect(toBoolean("", false)).toEqual(false);
+  });
+
+  test("returns default boolean value, when undefined", () => {
+    expect(toBoolean(undefined, true)).toEqual(true);
+    expect(toBoolean(undefined, false)).toEqual(false);
+  });
+});


### PR DESCRIPTION
A feature (#230) was added to the `cli` to give a user flexibility of allowing additional properties on types defined by the generator by omitting the `.passthrough()` deceleration on a `zod` schema - which should resolve #196

When trying this feature, I discovered it wasn't possible to set the flag `additionalPropsDefaultValue` correctly as the cli returns a `string` and the `openApiToZod` method expects a `boolean` for this value

I've refactored the `match` statement used for `withAlias` to be a helper method called `toBoolean` and consumed from the same location as `withAlias` does.