### PR TITLE
fix: discriminatedUnion allOf issue

### DIFF
--- a/.changeset/fix-discriminated-union-issue.md
+++ b/.changeset/fix-discriminated-union-issue.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": patch
+---
+
+Fix issue using discriminated union when there are multiple items within an allOf block by reverting to a union type for this case

--- a/lib/src/openApiToZod.test.ts
+++ b/lib/src/openApiToZod.test.ts
@@ -141,6 +141,130 @@ test("getSchemaAsZodString", () => {
                   "
     `);
 
+    // returns z.discriminatedUnion, when allOf has single object
+    expect(
+        getSchemaAsZodString({
+            type: "object",
+            oneOf: [
+                {
+                    type: "object",
+                    allOf: [
+                        {
+                            type: "object",
+                            required: ["type", "a"],
+                            properties: {
+                                type: {
+                                    type: "string",
+                                    enum: ["a"],
+                                },
+                                a: {
+                                    type: "string",
+                                },
+                            },
+                        }
+                    ]
+                },
+                {
+                    type: "object",
+                    allOf: [
+                        {
+                            type: "object",
+                            required: ["type", "b"],
+                            properties: {
+                                type: {
+                                    type: "string",
+                                    enum: ["b"],
+                                },
+                                b: {
+                                    type: "string",
+                                },
+                            },
+                        },
+                    ]
+                }
+            ],
+            discriminator: { propertyName: "type" },
+
+        })
+    ).toMatchInlineSnapshot(`
+    "
+                    z.discriminatedUnion("type", [z.object({ type: z.literal("a"), a: z.string() }).passthrough(), z.object({ type: z.literal("b"), b: z.string() }).passthrough()])
+                "
+    `);
+
+    // returns z.union, when allOf has multiple objects
+    expect(
+        getSchemaAsZodString({
+            type: "object",
+            oneOf: [
+                {
+                    type: "object",
+                    allOf: [
+                        {
+                            type: "object",
+                            required: ["type", "a"],
+                            properties: {
+                                type: {
+                                    type: "string",
+                                    enum: ["a"],
+                                },
+                                a: {
+                                    type: "string",
+                                },
+                            },
+                        },
+                        {
+                            type: "object",
+                            required: ["type", "c"],
+                            properties: {
+                                type: {
+                                    type: "string",
+                                    enum: ["c"],
+                                },
+                                c: {
+                                    type: "string",
+                                },
+                            },
+                        },
+                    ]
+                },
+                {
+                    type: "object",
+                    allOf: [
+                        {
+                            type: "object",
+                            required: ["type", "b"],
+                            properties: {
+                                type: {
+                                    type: "string",
+                                    enum: ["b"],
+                                },
+                                b: {
+                                    type: "string",
+                                },
+                            },
+                        },
+                        {
+                            type: "object",
+                            required: ["type", "d"],
+                            properties: {
+                                type: {
+                                    type: "string",
+                                    enum: ["d"],
+                                },
+                                d: {
+                                    type: "string",
+                                },
+                            },
+                        },
+                    ]
+                }
+            ],
+            discriminator: { propertyName: "type" },
+
+        })
+    ).toMatchInlineSnapshot('"z.union([z.object({ type: z.literal("a"), a: z.string() }).passthrough().and(z.object({ type: z.literal("c"), c: z.string() }).passthrough()), z.object({ type: z.literal("b"), b: z.string() }).passthrough().and(z.object({ type: z.literal("d"), d: z.string() }).passthrough())])"');
+
     expect(
         getSchemaAsZodString({
             type: "object",


### PR DESCRIPTION
An issue was previously raised #110 whereby the `z.discriminatedUnion` caused issues in the gererated schema.

It appears the issue is caused by the `z.and` type, this breaks inference when used within a `z.discriminatedUnion`.

In order to solve this, whenever there are multiple objects defined within an `allOf` block we should instead opt to use a `z.union` type instead; which then allows the `z.and` type to be infered correctly.