### PR TITLE
fix #257 to infer as object when only required array set

### DIFF
--- a/.changeset/selfish-pandas-repeat.md
+++ b/.changeset/selfish-pandas-repeat.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": minor
+---
+
+Fix #257 by inferring as object when only required array defined

--- a/lib/tests/array-oneOf-discriminated-union.test.ts
+++ b/lib/tests/array-oneOf-discriminated-union.test.ts
@@ -61,8 +61,14 @@ test("array-oneOf-discriminated-union", async () => {
 
       const ArrayRequest = z.array(
         z.discriminatedUnion("type", [
-          z.object({ type: z.literal("a") }).passthrough(),
-          z.object({ type: z.literal("b") }).passthrough(),
+          z
+            .object({ type: z.literal("a") })
+            .and(z.object({ a: z.unknown() }))
+            .passthrough(),
+          z
+            .object({ type: z.literal("b") })
+            .and(z.object({ b: z.unknown() }))
+            .passthrough(),
         ])
       );
 

--- a/lib/tests/infer-as-object-when-only-required-set.test.ts
+++ b/lib/tests/infer-as-object-when-only-required-set.test.ts
@@ -1,0 +1,12 @@
+import { getZodSchema } from "../src/openApiToZod";
+import { test, expect } from "vitest";
+
+test("infer-as-object-when-only-required-set", () => {
+    expect(
+        getZodSchema({
+            schema: {
+                required: ['name', 'email'],
+            },
+        })
+    ).toMatchInlineSnapshot('"z.object({}).and(z.object({ name: z.unknown(), email: z.unknown() })).passthrough()"');
+});

--- a/lib/tests/required-additional-props-not-in-properties.test.ts
+++ b/lib/tests/required-additional-props-not-in-properties.test.ts
@@ -1,0 +1,20 @@
+import { getZodSchema } from "../src/openApiToZod";
+import { test, expect } from "vitest";
+
+test("required-additional-props-not-in-properties", () => {
+    expect(
+        getZodSchema({
+            schema: {
+                properties: {
+                    name: {
+                        type: "string"
+                    },
+                    email: {
+                        type: "string"
+                    },
+                },
+                required: ['name', 'email', 'phone'],
+            },
+        })
+    ).toMatchInlineSnapshot('"z.object({ name: z.string(), email: z.string() }).and(z.object({ phone: z.unknown() })).passthrough()"');
+});


### PR DESCRIPTION
This is an attempt to fix #257 

Now `getZodSchema` would treat schema object with `required` defined as an array of type `object` and correctly infer the type.
The fix also checks extra properties in `required` array but not defined in `properties`, inferred as additional props.

The fix doesn't handle the case when `additionalProperties` are defined and mixed with `required` array. It seems that the current implementation doesn't handle the mix of `additionalProperties` and `properties` either. But it would be easy to append the `extraProperties` string generated from `required` to the code string generated for `additionalProperties`, after it's properly handled.