### PR TITLE
feat: add exportAllNamedSchemas option to allow exporting duplicate schemas with different names.

### DIFF
--- a/.changeset/blue-spies-nail.md
+++ b/.changeset/blue-spies-nail.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": minor
+---
+
+Add `exportAllNamedSchemas` option to allow exporting duplicate schemas with different names.

--- a/lib/src/getZodiosEndpointDefinitionList.ts
+++ b/lib/src/getZodiosEndpointDefinitionList.ts
@@ -83,7 +83,7 @@ export const getZodiosEndpointDefinitionList = (doc: OpenAPIObject, options?: Te
             const safeName = normalizeString(fallbackName);
 
             // if schema is already assigned to a variable, re-use that variable name
-            if (ctx.schemaByName[result]) {
+            if (!options?.exportAllNamedSchemas && ctx.schemaByName[result]) {
                 return ctx.schemaByName[result]!;
             }
 
@@ -95,7 +95,9 @@ export const getZodiosEndpointDefinitionList = (doc: OpenAPIObject, options?: Te
             let isVarNameAlreadyUsed = false;
             while ((isVarNameAlreadyUsed = Boolean(ctx.zodSchemaByName[formatedName]))) {
                 if (isVarNameAlreadyUsed) {
-                    if (ctx.zodSchemaByName[formatedName] === safeName) {
+                    if (options?.exportAllNamedSchemas && ctx.schemaByName[result]) {
+                        return ctx.schemaByName[result]!;
+                    } else if (ctx.zodSchemaByName[formatedName] === safeName) {
                         return formatedName;
                     } else {
                         reuseCount += 1;

--- a/lib/src/template-context.ts
+++ b/lib/src/template-context.ts
@@ -394,4 +394,11 @@ export type TemplateContextOptions = {
      * When true, returns a "responses" array with all responses (both success and errors)
      */
     withAllResponses?: boolean;
+    
+    /**
+     * When true, prevents using the exact same name for the same type
+     * For example, if 2 schemas have the same type, but different names, export each as separate schemas
+     * If 2 schemas have the same name but different types, export subsequent names with numbers appended
+     */
+    exportAllNamedSchemas?: boolean;
 };

--- a/lib/tests/export-all-named-schemas.test.ts
+++ b/lib/tests/export-all-named-schemas.test.ts
@@ -1,0 +1,253 @@
+import { OpenAPIObject } from "openapi3-ts";
+import { expect, test } from "vitest";
+import { generateZodClientFromOpenAPI, getZodClientTemplateContext } from "../src";
+
+test("export-all-named-schemas", async () => {
+    const openApiDoc: OpenAPIObject = {
+        openapi: "3.0.3",
+        info: { version: "1", title: "Example API" },
+        paths: {
+            "/export-all-named-schemas": {
+                get: {
+                    operationId: "getSchemaNameAlreadyUsed",
+                    responses: {
+                        "200": {
+                            content: {
+                                "application/json": {
+                                    schema: { type: "string" },
+                                },
+                            },
+                        },
+                    },
+                    parameters: [
+                        {
+                            name: "sameSchemaSameName",
+                            in: "query",
+                            schema: { type: "string", enum: ["xxx", "yyy", "zzz"] },
+                        },
+                    ],
+                },
+                put: {
+                    operationId: "putSchemaNameAlreadyUsed",
+                    responses: {
+                        "200": {
+                            content: {
+                                "application/json": {
+                                    schema: { type: "string" },
+                                },
+                            },
+                        },
+                    },
+                    parameters: [
+                        {
+                            name: "schemaNameAlreadyUsed",
+                            in: "query",
+                            schema: { type: "string", enum: ["aaa", "bbb", "ccc"] },
+                        },
+                    ],
+                },
+                delete: {
+                    operationId: "deleteSchemaNameAlreadyUsed",
+                    responses: {
+                        "200": {
+                            content: {
+                                "application/json": {
+                                    schema: { type: "string" },
+                                },
+                            },
+                        },
+                    },
+                    parameters: [
+                        {
+                            name: "sameSchemaSameName",
+                            in: "query",
+                            schema: { type: "string", enum: ["xxx", "yyy", "zzz"] },
+                        },
+                    ],
+                },
+                post: {
+                    operationId: "postSchemaNameAlreadyUsed",
+                    responses: {
+                        "200": {
+                            content: {
+                                "application/json": {
+                                    schema: { type: "string" },
+                                },
+                            },
+                        },
+                    },
+                    parameters: [
+                        {
+                            name: "schemaNameAlreadyUsed",
+                            in: "query",
+                            schema: { type: "string", enum: ["ggg", "hhh", "iii"] },
+                        },
+                    ],
+                },
+            },
+        },
+    };
+    const ctx = getZodClientTemplateContext(openApiDoc, { complexityThreshold: 2, exportAllNamedSchemas: true });
+    expect(ctx).toMatchInlineSnapshot(`
+      {
+          "circularTypeByName": {},
+          "emittedType": {},
+          "endpoints": [
+              {
+                  "description": undefined,
+                  "errors": [],
+                  "method": "get",
+                  "parameters": [
+                      {
+                          "name": "sameSchemaSameName",
+                          "schema": "sameSchemaSameName",
+                          "type": "Query",
+                      },
+                  ],
+                  "path": "/export-all-named-schemas",
+                  "requestFormat": "json",
+                  "response": "z.string()",
+              },
+              {
+                  "description": undefined,
+                  "errors": [],
+                  "method": "put",
+                  "parameters": [
+                      {
+                          "name": "schemaNameAlreadyUsed",
+                          "schema": "schemaNameAlreadyUsed",
+                          "type": "Query",
+                      },
+                  ],
+                  "path": "/export-all-named-schemas",
+                  "requestFormat": "json",
+                  "response": "z.string()",
+              },
+              {
+                  "description": undefined,
+                  "errors": [],
+                  "method": "delete",
+                  "parameters": [
+                      {
+                          "name": "sameSchemaSameName",
+                          "schema": "sameSchemaSameName",
+                          "type": "Query",
+                      },
+                  ],
+                  "path": "/export-all-named-schemas",
+                  "requestFormat": "json",
+                  "response": "z.string()",
+              },
+              {
+                  "description": undefined,
+                  "errors": [],
+                  "method": "post",
+                  "parameters": [
+                      {
+                          "name": "schemaNameAlreadyUsed",
+                          "schema": "schemaNameAlreadyUsed__2",
+                          "type": "Query",
+                      },
+                  ],
+                  "path": "/export-all-named-schemas",
+                  "requestFormat": "json",
+                  "response": "z.string()",
+              },
+          ],
+          "endpointsGroups": {},
+          "options": {
+              "baseUrl": "",
+              "withAlias": false,
+          },
+          "schemas": {
+              "sameSchemaSameName": "z.enum(["xxx", "yyy", "zzz"]).optional()",
+              "schemaNameAlreadyUsed": "z.enum(["aaa", "bbb", "ccc"]).optional()",
+              "schemaNameAlreadyUsed__2": "z.enum(["ggg", "hhh", "iii"]).optional()",
+          },
+          "types": {},
+      }
+    `);
+
+    const result = await generateZodClientFromOpenAPI({
+        disableWriteToFile: true,
+        openApiDoc,
+        options: { complexityThreshold: 2, exportAllNamedSchemas: true },
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+      "import { makeApi, Zodios, type ZodiosOptions } from "@zodios/core";
+      import { z } from "zod";
+
+      const sameSchemaSameName = z.enum(["xxx", "yyy", "zzz"]).optional();
+      const schemaNameAlreadyUsed = z.enum(["aaa", "bbb", "ccc"]).optional();
+      const schemaNameAlreadyUsed__2 = z.enum(["ggg", "hhh", "iii"]).optional();
+
+      export const schemas = {
+        sameSchemaSameName,
+        schemaNameAlreadyUsed,
+        schemaNameAlreadyUsed__2,
+      };
+
+      const endpoints = makeApi([
+        {
+          method: "get",
+          path: "/export-all-named-schemas",
+          requestFormat: "json",
+          parameters: [
+            {
+              name: "sameSchemaSameName",
+              type: "Query",
+              schema: sameSchemaSameName,
+            },
+          ],
+          response: z.string(),
+        },
+        {
+          method: "put",
+          path: "/export-all-named-schemas",
+          requestFormat: "json",
+          parameters: [
+            {
+              name: "schemaNameAlreadyUsed",
+              type: "Query",
+              schema: schemaNameAlreadyUsed,
+            },
+          ],
+          response: z.string(),
+        },
+        {
+          method: "delete",
+          path: "/export-all-named-schemas",
+          requestFormat: "json",
+          parameters: [
+            {
+              name: "sameSchemaSameName",
+              type: "Query",
+              schema: sameSchemaSameName,
+            },
+          ],
+          response: z.string(),
+        },
+        {
+          method: "post",
+          path: "/export-all-named-schemas",
+          requestFormat: "json",
+          parameters: [
+            {
+              name: "schemaNameAlreadyUsed",
+              type: "Query",
+              schema: schemaNameAlreadyUsed__2,
+            },
+          ],
+          response: z.string(),
+        },
+      ]);
+
+      export const api = new Zodios(endpoints);
+
+      export function createApiClient(baseUrl: string, options?: ZodiosOptions) {
+        return new Zodios(baseUrl, endpoints, options);
+      }
+      "
+    `);
+});


### PR DESCRIPTION
This PR provides a new option, `exportAllNamedSchemas`, to override that behavior and export all named schemas even if they are the same type. 

The default behavior was causing the same schema name to be used in multiple places and the semantics did not make sense. 

Example: 

This portion of schema with a complexity of 0 would result in a single `username: z.string()` schema set to both `username` and `password` query parameters, as well as any other parameters that are `schema.type: string`

```
  /user/login:
    get:
      tags:
        - user
      summary: Logs user into the system
      description: ""
      operationId: loginUser
      parameters:
        - name: username
          in: query
          description: The user name for login
          required: false
          schema:
            type: string
        - name: password
          in: query
          description: The password for login in clear text
          required: false
          schema:
            type: string
```
Result:
```
"parameters": [
    {
        "name": "username",
        "schema": "username",
        "type": "Query",
    },
    {
        "name": "password",
        "schema": "username",
        "type": "Query",
    },
],
```