### PR TITLE
fix: bug with exportAllNamedSchemas

### DIFF
--- a/.changeset/smooth-impalas-behave.md
+++ b/.changeset/smooth-impalas-behave.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": patch
+---
+
+Fix bug with `exportAllNamedSchemas` option where schemas will reuse last schema name with matching schema rather than it's own name that has already been used before.

--- a/lib/src/CodeMeta.ts
+++ b/lib/src/CodeMeta.ts
@@ -7,7 +7,7 @@ import { getSchemaComplexity } from "./schema-complexity";
 export type ConversionTypeContext = {
     resolver: DocumentResolver;
     zodSchemaByName: Record<string, string>;
-    schemaByName: Record<string, string>;
+    schemaByName: Record<string, string[]>;
 };
 
 export type CodeMetaData = {

--- a/lib/src/CodeMeta.ts
+++ b/lib/src/CodeMeta.ts
@@ -7,7 +7,8 @@ import { getSchemaComplexity } from "./schema-complexity";
 export type ConversionTypeContext = {
     resolver: DocumentResolver;
     zodSchemaByName: Record<string, string>;
-    schemaByName: Record<string, string[]>;
+    schemaByName: Record<string, string>;
+    schemasByName?: Record<string, string[]>;
 };
 
 export type CodeMetaData = {

--- a/lib/src/getZodiosEndpointDefinitionList.test.ts
+++ b/lib/src/getZodiosEndpointDefinitionList.test.ts
@@ -439,7 +439,9 @@ test("getZodiosEndpointDefinitionList /pet without schema ref", () => {
               "resolveSchemaName": [Function],
           },
           "schemaByName": {
-              "Pet.and(Reason)": "updatePet_Body",
+              "Pet.and(Reason)": [
+                  "updatePet_Body",
+              ],
           },
           "zodSchemaByName": {
               "Category": "z.object({ id: z.number().int(), name: z.string() }).partial().passthrough()",

--- a/lib/src/getZodiosEndpointDefinitionList.test.ts
+++ b/lib/src/getZodiosEndpointDefinitionList.test.ts
@@ -439,9 +439,7 @@ test("getZodiosEndpointDefinitionList /pet without schema ref", () => {
               "resolveSchemaName": [Function],
           },
           "schemaByName": {
-              "Pet.and(Reason)": [
-                  "updatePet_Body",
-              ],
+              "Pet.and(Reason)": "updatePet_Body",
           },
           "zodSchemaByName": {
               "Category": "z.object({ id: z.number().int(), name: z.string() }).partial().passthrough()",

--- a/lib/src/getZodiosEndpointDefinitionList.ts
+++ b/lib/src/getZodiosEndpointDefinitionList.ts
@@ -84,7 +84,7 @@ export const getZodiosEndpointDefinitionList = (doc: OpenAPIObject, options?: Te
 
             // if schema is already assigned to a variable, re-use that variable name
             if (!options?.exportAllNamedSchemas && ctx.schemaByName[result]) {
-                return ctx.schemaByName[result]!;
+                return ctx.schemaByName[result]![0]!;
             }
 
             // result is complex and would benefit from being re-used
@@ -95,8 +95,8 @@ export const getZodiosEndpointDefinitionList = (doc: OpenAPIObject, options?: Te
             let isVarNameAlreadyUsed = false;
             while ((isVarNameAlreadyUsed = Boolean(ctx.zodSchemaByName[formatedName]))) {
                 if (isVarNameAlreadyUsed) {
-                    if (options?.exportAllNamedSchemas && ctx.schemaByName[result]) {
-                        return ctx.schemaByName[result]!;
+                    if (options?.exportAllNamedSchemas && ctx.schemaByName[result]?.includes(formatedName)) {
+                        return formatedName;
                     } else if (ctx.zodSchemaByName[formatedName] === safeName) {
                         return formatedName;
                     } else {
@@ -107,7 +107,13 @@ export const getZodiosEndpointDefinitionList = (doc: OpenAPIObject, options?: Te
             }
 
             ctx.zodSchemaByName[formatedName] = result;
-            ctx.schemaByName[result] = formatedName;
+
+            if (options?.exportAllNamedSchemas) {
+                ctx.schemaByName[result] = (ctx.schemaByName[result] ?? []).concat(formatedName);
+            } else {
+                ctx.schemaByName[result] = [formatedName];
+            }
+
             return formatedName;
         }
 

--- a/lib/tests/export-all-named-schemas.test.ts
+++ b/lib/tests/export-all-named-schemas.test.ts
@@ -59,6 +59,11 @@ test("export-all-named-schemas", async () => {
                     },
                     parameters: [
                         {
+                            name: "sameSchemaDifferentName",
+                            in: "query",
+                            schema: { type: "string", enum: ["xxx", "yyy", "zzz"] },
+                        },
+                        {
                             name: "sameSchemaSameName",
                             in: "query",
                             schema: { type: "string", enum: ["xxx", "yyy", "zzz"] },
@@ -129,6 +134,11 @@ test("export-all-named-schemas", async () => {
                   "method": "delete",
                   "parameters": [
                       {
+                          "name": "sameSchemaDifferentName",
+                          "schema": "sameSchemaDifferentName",
+                          "type": "Query",
+                      },
+                      {
                           "name": "sameSchemaSameName",
                           "schema": "sameSchemaSameName",
                           "type": "Query",
@@ -160,6 +170,7 @@ test("export-all-named-schemas", async () => {
               "withAlias": false,
           },
           "schemas": {
+              "sameSchemaDifferentName": "z.enum(["xxx", "yyy", "zzz"]).optional()",
               "sameSchemaSameName": "z.enum(["xxx", "yyy", "zzz"]).optional()",
               "schemaNameAlreadyUsed": "z.enum(["aaa", "bbb", "ccc"]).optional()",
               "schemaNameAlreadyUsed__2": "z.enum(["ggg", "hhh", "iii"]).optional()",
@@ -180,11 +191,13 @@ test("export-all-named-schemas", async () => {
 
       const sameSchemaSameName = z.enum(["xxx", "yyy", "zzz"]).optional();
       const schemaNameAlreadyUsed = z.enum(["aaa", "bbb", "ccc"]).optional();
+      const sameSchemaDifferentName = z.enum(["xxx", "yyy", "zzz"]).optional();
       const schemaNameAlreadyUsed__2 = z.enum(["ggg", "hhh", "iii"]).optional();
 
       export const schemas = {
         sameSchemaSameName,
         schemaNameAlreadyUsed,
+        sameSchemaDifferentName,
         schemaNameAlreadyUsed__2,
       };
 
@@ -220,6 +233,11 @@ test("export-all-named-schemas", async () => {
           path: "/export-all-named-schemas",
           requestFormat: "json",
           parameters: [
+            {
+              name: "sameSchemaDifferentName",
+              type: "Query",
+              schema: sameSchemaDifferentName,
+            },
             {
               name: "sameSchemaSameName",
               type: "Query",


### PR DESCRIPTION
After updating the package to 1.16.0 I realized it was only half a fix. When using the `exportAllNamedSchemas` option it did create new names for duplicate schemas, but then if it tried to use those names again it would end up using the last known name for the schema instead.
