### PR TITLE
fix: multiline description

### DIFF
--- a/.changeset/chilly-needles-pump.md
+++ b/.changeset/chilly-needles-pump.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": patch
+---
+
+Fix multiline descriptions when `describe` is enabled

--- a/lib/src/getZodiosEndpointDefinitionList.ts
+++ b/lib/src/getZodiosEndpointDefinitionList.ts
@@ -249,7 +249,7 @@ export const getZodiosEndpointDefinitionList = (doc: OpenAPIObject, options?: Te
                     }
 
                     if (options?.withDescription && paramSchema) {
-                        (paramSchema as SchemaObject).description = (paramItem.description ?? "")?.replace("\n", "");
+                        (paramSchema as SchemaObject).description = (paramItem.description ?? "").trim();
                     }
 
                     // resolve ref if needed, and fallback to default (unknown) value if needed

--- a/lib/src/openApiToZod.ts
+++ b/lib/src/openApiToZod.ts
@@ -302,7 +302,11 @@ export const getZodChain = ({ schema, meta, options }: ZodChainArgs) => {
         .otherwise(() => void 0);
 
     if (typeof schema.description === "string" && schema.description !== "" && options?.withDescription) {
-        chains.push(`describe("${schema.description}")`);
+        if (["\n", "\r", "\r\n"].some((c) => String.prototype.includes.call(schema.description, c))) {
+            chains.push(`describe(\`${schema.description}\`)`);
+        } else {
+            chains.push(`describe("${schema.description}")`);
+        }
     }
 
     const output = chains

--- a/lib/tests/description-in-zod.test.ts
+++ b/lib/tests/description-in-zod.test.ts
@@ -31,6 +31,23 @@ test("description-in-zod", async () => {
                             },
                             description: "bar description",
                         },
+                        {
+                            in: "query",
+                            name: "baz",
+                            schema: {
+                                type: "number",
+                                enum: [1.3, 34.1, -57.89],
+                            },
+                            description: "baz\nmultiline\ndescription",
+                        },
+                        {
+                            in: "query",
+                            name: "qux",
+                            schema: {
+                                type: "string",
+                            },
+                            description: "      ", // spaces only description
+                        },
                     ],
                     responses: {
                         "200": {
@@ -72,6 +89,21 @@ test("description-in-zod", async () => {
                 .union([z.literal(1.2), z.literal(34), z.literal(-56.789)])
                 .describe("bar description")
                 .optional(),
+            },
+            {
+              name: "baz",
+              type: "Query",
+              schema: z
+                .union([z.literal(1.3), z.literal(34.1), z.literal(-57.89)])
+                .describe(
+                  \`baz\nmultiline\ndescription\`
+                )
+                .optional(),
+            },
+            {
+              name: "qux",
+              type: "Query",
+              schema: z.string().optional(),
             },
           ],
           response: z.void(),


### PR DESCRIPTION
Properly handles multiline descriptions (currently, it's producing invalid code if it has more than 2 lines [because `replace` is used instead of `replaceAll`]. fixed to not ignore multiple lines at all)

Tests updated accordingly

Also kept the current behavior of using double quotes if the description hasn't multiple lines, to avoid updating lots of tests and unnecessary change in currently generated code