### PR TITLE
feat: add nullish to partial objects

### DIFF
--- a/.changeset/tame-spies-scream.md
+++ b/.changeset/tame-spies-scream.md
@@ -1,0 +1,5 @@
+---
+"openapi-zod-client": minor
+---
+
+Add `addNullishToPartial` option and `--add-nullish-to-partial` flag that adds `.nullish()` to all properties in `.partial()` objects

--- a/lib/src/cli.ts
+++ b/lib/src/cli.ts
@@ -61,6 +61,11 @@ cli.command("<input>", "path/url to OpenAPI/Swagger document as json/yaml")
         "Use strict validation for objects so we don't allow unknown keys. Defaults to false.",
         { default: false }
     )
+    .option(
+        "--add-nullish-to-partial",
+        "Adds `null` and `undefined` to the type of all properties in partial objects. Defaults to false.",
+        { default: false }
+    )
     .action(async (input, options) => {
         console.log("Retrieving OpenAPI document from", input);
         const openApiDoc = (await SwaggerParser.bundle(input)) as OpenAPIObject;
@@ -92,6 +97,7 @@ cli.command("<input>", "path/url to OpenAPI/Swagger document as json/yaml")
                 allReadonly: options.allReadonly,
                 strictObjects: options.strictObjects,
                 additionalPropertiesDefaultValue,
+                addNullishToPartial: options.addNullishToPartial,
             },
         });
         console.log(`Done generating <${distPath}> !`);

--- a/lib/src/openApiToZod.ts
+++ b/lib/src/openApiToZod.ts
@@ -268,7 +268,7 @@ export function getZodSchema({ schema, ctx, meta: inheritedMeta, options }: Conv
 
                 const propCode =
                     getZodSchema({ schema: propSchema, ctx, meta: propMetadata, options }) +
-                    getZodChain({ schema: propActualSchema as SchemaObject, meta: propMetadata, options });
+                    getZodChain({ schema: propActualSchema as SchemaObject, meta: propMetadata, isPartial, options });
 
                 return [prop, propCode.toString()];
             });
@@ -290,9 +290,9 @@ export function getZodSchema({ schema, ctx, meta: inheritedMeta, options }: Conv
     throw new Error(`Unsupported schema type: ${schemaType}`);
 }
 
-type ZodChainArgs = { schema: SchemaObject; meta?: CodeMetaData; options?: TemplateContext["options"] };
+type ZodChainArgs = { schema: SchemaObject; meta?: CodeMetaData; isPartial?: boolean; options?: TemplateContext["options"] };
 
-export const getZodChain = ({ schema, meta, options }: ZodChainArgs) => {
+export const getZodChain = ({ schema, meta, isPartial, options }: ZodChainArgs) => {
     const chains: string[] = [];
 
     match(schema.type)
@@ -307,6 +307,10 @@ export const getZodChain = ({ schema, meta, options }: ZodChainArgs) => {
         } else {
             chains.push(`describe("${schema.description}")`);
         }
+    }
+
+    if (isPartial && options?.addNullishToPartial) {
+        chains.push("nullish()");
     }
 
     const output = chains

--- a/lib/src/template-context.ts
+++ b/lib/src/template-context.ts
@@ -403,4 +403,14 @@ export type TemplateContextOptions = {
      * If 2 schemas have the same name but different types, export subsequent names with numbers appended
      */
     exportAllNamedSchemas?: boolean;
+
+    /**
+     * When true, adds .nullish() to all .partial() schemas
+     * For example, if a schema is defined as z.object({ foo: z.string() }).partial(), it will be
+     * exported as z.object({ foo: z.string().nullish() }).partial()
+     *
+     * This is a workaround for a bug in zod where .partial() schemas do not allow null values
+     * https://github.com/colinhacks/zod/issues/2893
+     */
+    addNullishToPartial?: boolean;
 };

--- a/lib/tests/add-nullish-to-optional.test.ts
+++ b/lib/tests/add-nullish-to-optional.test.ts
@@ -1,0 +1,22 @@
+import { getZodSchema } from "../src/openApiToZod";
+import { test, expect } from "vitest";
+
+test("add-nullish-to-optional", () => {
+    expect(
+        getZodSchema({
+            schema: {
+                properties: {
+                    name: {
+                        type: "string",
+                    },
+                    email: {
+                        type: "string",
+                    },
+                },
+            },
+            options: {
+                addNullishToPartial: true,
+            },
+        })
+    ).toMatchInlineSnapshot('"z.object({ name: z.string().nullish(), email: z.string().nullish() }).partial().passthrough()"');
+});


### PR DESCRIPTION
This PR adds a new option, `addNullishToPartial`, as well as a new CLI flag, `--add-nullish-to-partial`, that adds `.nullish()` to all `.partial()` objects, as a workaround for the issue https://github.com/colinhacks/zod/issues/2893

This is because partial objects allow `undefined` values, but not `null` values, which is causing an unexpected error for an API I'm currently integrating.

As there isn't any other way to achieve this with the currently-implemented options, I've added this feature as an opt-in flag with no breaking changes.