### PR TITLE
Fixes: Null and undefined value handling

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -13,7 +13,7 @@
         "openapi-zod-client": "./bin.js"
     },
     "scripts": {
-        "test": "vitest",
+        "test": "export NODE_OPTIONS=$(echo '$NODE_OPTIONS' | sed 's/--openssl-legacy-provider//') vitest",
         "test:ci": "vitest run",
         "lint:ts": "tsc --noEmit",
         "lint": "eslint -c .eslintrc.build.js './src/**/*.ts' --cache --format=pretty",

--- a/lib/tests/jsdoc.test.ts
+++ b/lib/tests/jsdoc.test.ts
@@ -143,13 +143,13 @@ type ComplexObject = Partial<{
    * @minimum 0
    * @maximum 10
    */
-  manyTagsNum: number;
+  manyTagsNum: number | undefined;
   /**
    * A boolean
    *
    * @default true
    */
-  bool: boolean;
+  bool: boolean | undefined;
   ref: SimpleObject;
   /**
    * An array of SimpleObject


### PR DESCRIPTION
Three fixes
1. When there is a default value, the TS type will be optional. When .default() is used, Zod infers the input field to be optional, even if the field is required. This makes sense because we are parsing inputs. The strictly correct way is to build two types, Type and TypeInput. But it is bloated. This serves its purpose.
2. Scattered nullable additions that we forgot before
3. ZodSchema chaining for "oneOf" types. I suspect there are more bugs like this, but for future fixes.

This should now work on both the full petstore.yaml example and the gigantic [openai specs](https://github.com/openai/openai-openapi)