### PR TITLE
Fix endpoint groups path

### DIFF
--- a/lib/src/getZodiosEndpointDefinitionList.ts
+++ b/lib/src/getZodiosEndpointDefinitionList.ts
@@ -25,7 +25,6 @@ import {
     normalizeString,
     pathParamToVariableName,
     pathToVariableName,
-    replaceHyphenatedPath,
 } from "./utils";
 
 const voidSchema = "z.void()";
@@ -164,7 +163,7 @@ export const getZodiosEndpointDefinitionList = (doc: OpenAPIObject, options?: Te
             const operationName = getOperationAlias(path, method, operation);
             let endpointDefinition: EndpointDefinitionWithRefs = {
                 method: method as EndpointDefinitionWithRefs["method"],
-                path: replaceHyphenatedPath(path),
+                path,
                 ...(options?.withAlias && { alias: operationName }),
                 description: operation.description,
                 requestFormat: "json",


### PR DESCRIPTION
When we have a path param with a dash, it is replaced to camelCase, then its obviously not possible to find the related path in the spec when doing
```
const pathItemObject: PathItemObject = openApiDoc.paths[endpoint.path] ?? openApiDoc.paths[operationPath];
```

We shouldn't manipulate the path at this point